### PR TITLE
Reorganize container go tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#ignore the go path, populated with other repositories through init
+go/
+
+#ignore metal3 dev env folder, git repo on its own
+metal3-dev-env

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ $ ./tools/update-nordix-repos-master.sh
 $ ./container/run-workspace.sh
 ```
 
+### Running the tests
+
+All the following actions take place in the container. Otherwise
+check you have installed everything properly (go 1.12, bazel, operator-sdk etc.)
+
+If you want to run the metal3 tests, you first need to fetch the dependencies.
+
+```
+$ dep ensure
+```
+
+Then for all repositories :
+```
+$ make test
+```
+
 ## Ways of working
 
 * [Github Workflow](wow/github-workflow.md)

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,42 +1,56 @@
 FROM ubuntu:18.04
 
+# Install the minimum dependencies
+# (software-properties-common for add-apt-repository)
 RUN apt-get update && \
-    apt-get install -y software-properties-common
-
-RUN add-apt-repository -y ppa:longsleep/golang-backports && \
-    apt-get update && apt-get install -y \
+    apt-get install -y \
     git \
     apt-transport-https \
     ca-certificates \
     curl \
     gnupg-agent \
-    golang-go \
-    golint
-RUN curl -LO https://raw.githubusercontent.com/golang/dep/master/install.sh && \
-    mkdir -p /root/go/bin && chmod +x install.sh && ./install.sh && rm install.sh
-RUN curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu && \
-    chmod +x operator-sdk-v0.9.0-x86_64-linux-gnu && cp operator-sdk-v0.9.0-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-v0.9.0-x86_64-linux-gnu
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    software-properties-common
+
+#Add repos and install Go, Docker and Bazel
+RUN add-apt-repository -y ppa:longsleep/golang-backports && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
+    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
     add-apt-repository \
     "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) \
-    stable" && \
-    apt-get update && apt-get install docker-ce-cli
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    $(lsb_release -cs) stable" && \
+    add-apt-repository \
+    "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" && \
+    apt-get update && apt-get install -y \
+    docker-ce-cli \
+    bazel \
+    golang-go \
+    golint
+
+ENV GOPATH=/data/go
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/data/go/bin
+ENV GO111MODULE=on
+
+#Install Golang dep, operator-sdk, Kubectl, Kustomize and kubebuilder
+RUN curl -LO https://raw.githubusercontent.com/golang/dep/master/install.sh && \
+    mkdir -p /data/go/bin && chmod +x install.sh && ./install.sh && rm install.sh && \
+    mv /data/go/bin/dep /usr/local/bin && \
+    \
+    curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/v0.9.0/operator-sdk-v0.9.0-x86_64-linux-gnu && \
+    chmod +x operator-sdk-v0.9.0-x86_64-linux-gnu && cp operator-sdk-v0.9.0-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-v0.9.0-x86_64-linux-gnu && \
+    \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin/kubectl
-
-ENV GOPATH=/root/go
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/go/bin
-
-RUN curl -LO https://raw.githubusercontent.com/Nordix/cluster-api-provider-baremetal/master/tools/install_kustomize.sh && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    \
+    curl -LO https://raw.githubusercontent.com/Nordix/cluster-api-provider-baremetal/master/tools/install_kustomize.sh && \
     chmod +x ./install_kustomize.sh && ./install_kustomize.sh && rm install_kustomize.sh && \
+    \
     curl -LO https://raw.githubusercontent.com/Nordix/cluster-api-provider-baremetal/master/tools/install_kubebuilder.sh && \
     chmod +x ./install_kubebuilder.sh && ./install_kubebuilder.sh && rm install_kubebuilder.sh && \
-    mv kubebuilder /usr/local
+    mv kubebuilder /usr/local && \
+    \
+    mkdir -p /data
 
-
-RUN mkdir /data
 WORKDIR /data
 
 CMD ["/bin/bash"]

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -24,11 +24,12 @@ RUN add-apt-repository -y ppa:longsleep/golang-backports && \
     docker-ce-cli \
     bazel \
     golang-go \
-    golint
+    golint \
+    shellcheck
 
 ENV GOPATH=/data/go
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/data/go/bin
-ENV GO111MODULE=on
+
 
 #Install Golang dep, operator-sdk, Kubectl, Kustomize and kubebuilder
 RUN curl -LO https://raw.githubusercontent.com/golang/dep/master/install.sh && \
@@ -44,10 +45,14 @@ RUN curl -LO https://raw.githubusercontent.com/golang/dep/master/install.sh && \
     \
     curl -LO https://raw.githubusercontent.com/Nordix/cluster-api-provider-baremetal/master/tools/install_kustomize.sh && \
     chmod +x ./install_kustomize.sh && ./install_kustomize.sh && rm install_kustomize.sh && \
+    mv /data/go/bin/kustomize /usr/local/bin && \
     \
     curl -LO https://raw.githubusercontent.com/Nordix/cluster-api-provider-baremetal/master/tools/install_kubebuilder.sh && \
     chmod +x ./install_kubebuilder.sh && ./install_kubebuilder.sh && rm install_kubebuilder.sh && \
     mv kubebuilder /usr/local && \
+    \
+    go get github.com/securego/gosec/cmd/gosec && \
+    mv /data/go/bin/gosec /usr/local/bin && \
     \
     mkdir -p /data
 

--- a/container/run-workspace.sh
+++ b/container/run-workspace.sh
@@ -2,7 +2,7 @@
 
 set -ue
 
-SCRIPTPATH=$( cd $(dirname $(readlink -f $0)) >/dev/null 2>&1 ; pwd -P )
+SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
 
-docker build ${SCRIPTPATH} -t workspace
-docker run --network host -v ${SCRIPTPATH}/../:/data -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.kube/:/root/.kube -v ${HOME}/.minikube:${HOME}/.minikube --rm -it --name workspace workspace
+docker build "${SCRIPTPATH}" -t workspace
+docker run --network host -v "${SCRIPTPATH}"/../:/data -v /var/run/docker.sock:/var/run/docker.sock -v "${HOME}"/.kube/:/root/.kube -v "${HOME}"/.minikube:"${HOME}"/.minikube --rm -it --name workspace workspace

--- a/container/run-workspace.sh
+++ b/container/run-workspace.sh
@@ -2,7 +2,7 @@
 
 set -ue
 
-SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -f "${0}")")"
 
 docker build "${SCRIPTPATH}" -t workspace
 docker run --network host -v "${SCRIPTPATH}"/../:/data -v /var/run/docker.sock:/var/run/docker.sock -v "${HOME}"/.kube/:/root/.kube -v "${HOME}"/.minikube:"${HOME}"/.minikube --rm -it --name workspace workspace

--- a/tools/init-repo.sh
+++ b/tools/init-repo.sh
@@ -20,10 +20,16 @@ setup_repo () {
   cd ..
 }
 
-setup_repo cluster-api kubernetes-sigs
-for repo in metal3-dev-env cluster-api-provider-baremetal baremetal-operator
-do
-    setup_repo ${repo} metal3-io
-done
+setup_go_repo () {
+  mkdir -p ${3}
+  pushd ${3}
+  setup_repo ${1} ${2}
+  popd
+}
+
+setup_go_repo cluster-api kubernetes-sigs go/src/sigs.k8s.io
+setup_repo metal3-dev-env metal3-io
+setup_go_repo cluster-api-provider-baremetal metal3-io go/src/github.com/metal3-io
+setup_go_repo baremetal-operator metal3-io go/src/github.com/metal3-io
 
 popd

--- a/tools/init-repo.sh
+++ b/tools/init-repo.sh
@@ -2,15 +2,15 @@
 
 set -ue
 
-SCRIPTPATH=$( cd $(dirname $(readlink -f $0)) >/dev/null 2>&1 ; pwd -P )
+SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
 
-pushd ${SCRIPTPATH}
+pushd "${SCRIPTPATH}"
 cd ..
 
 setup_repo () {
-  git clone git@github.com:Nordix/${1}.git
-  cd ${1}
-  git remote add upstream git@github.com:${2}/${1}.git
+  git clone git@github.com:Nordix/"${1}".git
+  cd "${1}"
+  git remote add upstream git@github.com:"${2}"/"${1}".git
   git remote set-url --push upstream no_push
   git remote -v
   # Update "master" on Nordix
@@ -21,9 +21,9 @@ setup_repo () {
 }
 
 setup_go_repo () {
-  mkdir -p ${3}
-  pushd ${3}
-  setup_repo ${1} ${2}
+  mkdir -p "${3}"
+  pushd "${3}"
+  setup_repo "${1}" "${2}"
   popd
 }
 

--- a/tools/init-repo.sh
+++ b/tools/init-repo.sh
@@ -2,7 +2,7 @@
 
 set -ue
 
-SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -f "${0}")")"
 
 pushd "${SCRIPTPATH}"
 cd ..

--- a/tools/run-capb-tests.sh
+++ b/tools/run-capb-tests.sh
@@ -2,13 +2,6 @@
 
 set -ue
 
-SCRIPTPATH=$( cd $(dirname $(readlink -f $0)) >/dev/null 2>&1 ; pwd -P )
-
-cd ${SCRIPTPATH}
-cd ..
-
-mkdir /root/go/src
-cp -r cluster-api-provider-baremetal /root/go/src
-cd /root/go/src/cluster-api-provider-baremetal
+cd /data/go/src/github.com/metal3-io/cluster-api-provider-baremetal
 dep ensure
 make test

--- a/tools/update-nordix-repos-master.sh
+++ b/tools/update-nordix-repos-master.sh
@@ -7,7 +7,7 @@
 
 set -ue
 
-SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
+SCRIPTPATH="$(dirname "$(readlink -f "${0}")")"
 
 pushd "${SCRIPTPATH}"
 cd ..

--- a/tools/update-nordix-repos-master.sh
+++ b/tools/update-nordix-repos-master.sh
@@ -12,13 +12,13 @@ SCRIPTPATH=$( cd $(dirname $(readlink -f $0)) >/dev/null 2>&1 ; pwd -P )
 pushd ${SCRIPTPATH}
 cd ..
 
-UPDATE_REPO=${1:-cluster-api metal3-dev-env cluster-api-provider-baremetal baremetal-operator}
+UPDATE_REPO=${1:-go/src/sigs.k8s.io/cluster-api metal3-dev-env go/src/github.com/metal3-io/cluster-api-provider-baremetal go/src/github.com/metal3-io/baremetal-operator}
 UPDATE_BRANCH=${2:-master}
 
 for repo in $UPDATE_REPO
 do
   echo "Updating $repo"
-  cd $repo
+  pushd $repo
   # Update "master" on Nordix
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   git checkout $UPDATE_BRANCH
@@ -26,7 +26,7 @@ do
   git rebase upstream/master
   git push
   git checkout $BRANCH
-  cd ..
+  popd
   echo -e "\n"
 done
 

--- a/tools/update-nordix-repos-master.sh
+++ b/tools/update-nordix-repos-master.sh
@@ -7,25 +7,25 @@
 
 set -ue
 
-SCRIPTPATH=$( cd $(dirname $(readlink -f $0)) >/dev/null 2>&1 ; pwd -P )
+SCRIPTPATH="$( cd "$(dirname "$(readlink -f "${0}")")" >/dev/null 2>&1 ; pwd -P )"
 
-pushd ${SCRIPTPATH}
+pushd "${SCRIPTPATH}"
 cd ..
 
-UPDATE_REPO=${1:-go/src/sigs.k8s.io/cluster-api metal3-dev-env go/src/github.com/metal3-io/cluster-api-provider-baremetal go/src/github.com/metal3-io/baremetal-operator}
-UPDATE_BRANCH=${2:-master}
+UPDATE_REPO="${1:-go/src/sigs.k8s.io/cluster-api metal3-dev-env go/src/github.com/metal3-io/cluster-api-provider-baremetal go/src/github.com/metal3-io/baremetal-operator}"
+UPDATE_BRANCH="${2:-master}"
 
-for repo in $UPDATE_REPO
+for repo in ${UPDATE_REPO}
 do
-  echo "Updating $repo"
-  pushd $repo
+  echo "Updating ${repo}"
+  pushd "${repo}"
   # Update "master" on Nordix
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  git checkout $UPDATE_BRANCH
+  git checkout "${UPDATE_BRANCH}"
   git fetch upstream
   git rebase upstream/master
   git push
-  git checkout $BRANCH
+  git checkout "${BRANCH}"
   popd
   echo -e "\n"
 done


### PR DESCRIPTION
Move repos around to be correctly located in the go path, install Bazel and change the gitignore to ignore the other repositories and go path