### PR TITLE
Fix credentials ID for nordix update job

### DIFF
--- a/ci/jobs/update_nordix_repos.pipeline
+++ b/ci/jobs/update_nordix_repos.pipeline
@@ -1,6 +1,6 @@
 ci_git_url = "https://github.com/Nordix/airship-dev-tools.git"
 ci_git_branch = "master"
-ci_git_credential_id = "nordix-airship-ci"
+ci_git_credential_id = "nordix-airship-github-ssh"
 
 pipeline {
   agent { label 'airship-static-workers' }
@@ -38,4 +38,3 @@ pipeline {
     }
   }
 }
-


### PR DESCRIPTION
The actual credential is https://jenkins.nordix.org/credentials/store/system/domain/_/credential/nordix-airship-github-ssh/update
The error was https://jenkins.nordix.org/view/Airship/job/airship_update_nordix_repos/161/console