### PR TITLE
CI: Remove generation of Metal3 CentOS node image

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -139,26 +139,5 @@ pipeline {
         }
       }
     }
-    stage('Building Metal3 CentOS node image'){
-      options {
-        timeout(time: 60, unit: 'MINUTES')
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-
-            /* Generate Metal3 CentOS node image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_centos_image.sh \
-              /data/id_rsa_airshipci 1 \
-              provision_node_image_centos.sh"
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
-the image size turned out to be too large
-optimization efforts did not reduce the image size enough