### PR TITLE
Add sudo in image building for metal3

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image.sh
@@ -8,10 +8,10 @@ APT::Periodic::Update-Package-Lists "0";
 APT::Periodic::Unattended-Upgrade "0";
 EOF
 
-systemctl disable apt-daily-upgrade.timer
-systemctl disable apt-daily.timer
-systemctl stop apt-daily-upgrade.timer
-systemctl stop apt-daily.timer
+sudo systemctl disable apt-daily-upgrade.timer
+sudo systemctl disable apt-daily.timer
+sudo systemctl stop apt-daily-upgrade.timer
+sudo systemctl stop apt-daily.timer
 
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 


### PR DESCRIPTION
Missing sudo causes the image building to fail