### PR TITLE
Generate admin.conf before the cluster is created.

### DIFF
--- a/tools/deterministic_admin-conf_generation/README.md
+++ b/tools/deterministic_admin-conf_generation/README.md
@@ -1,0 +1,53 @@
+# Deterministic admin.conf generation for accessing k8s cluster
+
+Given a ```ca.key``` and ```ca.crt``` we would like to create _admin.conf for accessing a kubernetes cluster.
+
+Note:
+- The cluster is not setup yet.
+- The file is named ```_admin```.conf to distinguish it from the one automatically created during ```kubeadm init```
+# Steps
+1. Get ```ca.key``` and ```ca.crt``` files
+2. Create _admin.conf with the provided script
+3. Create a kubernetes cluster using the ```ca.key``` and ```ca.crt```
+4. Access the kubernetes cluster using the pre-created _admin.conf
+5. Destroy and create the cluster multiple times to see the _admin.conf remains valid
+
+The ```admin.sh``` performs step 2 in the above list.
+
+# Usage
+
+The script takes the following arguments, only the ```endpoint`` is mandatory
+
+```
+1 - a path to ca.crt
+2 - a path to ca.key
+3 - an enpoint address
+```
+
+Examples:
+
+When providing all three arguments
+```
+./admin.sh /tmp/ca.cert /tmp/ca.key https://172.17.0.2:6443
+```
+To verify that the generated _admin.conf is correct, run the following.
+
+```
+kubectl get pods --kubeconfig=_admin.conf
+```
+
+When providing only the end point
+```
+./admin.sh https://172.17.0.2:6443
+```
+
+when you are not providing ca.crt and ca.key, then the script generates them for you.
+However, you need to make sure that ```kubeadm init``` is run with those crts. Or else you will get the following error.
+
+
+```
+kubectl get pods --kubeconfig=_admin.conf
+```
+```
+Unable to connect to the server: x509: certificate signed by unknown authority
+```

--- a/tools/deterministic_admin-conf_generation/admin.sh
+++ b/tools/deterministic_admin-conf_generation/admin.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -eux
+
+if [ $# -lt 1 ]; then
+  echo 1>&2 "Usage: $0 [ca.crt ca.key] <api end point (https://IP:port or https://domainname:port>"
+  exit 3
+fi
+
+function generate_ca_certs() {
+  openssl genrsa -out ./credentials/ca.key 2048
+  openssl req -new -key ./credentials/ca.key -subj "/CN=KUBERNETES-CA" -out ./credentials/ca.csr
+  openssl x509 -req -in ./credentials/ca.csr -signkey ./credentials/ca.key -CAcreateserial  -out ./credentials/ca.crt -days 3653
+  rm ./credentials/ca.csr
+}
+
+# if ca.key and ca.crt are not provided, then create them
+# if ca.key and ca.crt are provided, then copy them to the right location.
+if [ $# -eq 1 ]; then
+   generate_ca_certs
+   export K8S_ENDPOINT=${1}
+else
+   cp "${1}" ./credentials/ca.crt
+   cp "${2}" ./credentials/ca.key
+   export K8S_ENDPOINT=${3}
+fi
+
+openssl genrsa -out ./credentials/admin.key 2048
+openssl req -new -key ./credentials/admin.key -subj "/CN=admin/O=system:masters" -out ./credentials/admin.csr
+openssl x509 -req -in ./credentials/admin.csr -CA ./credentials/ca.crt -CAkey ./credentials/ca.key -CAcreateserial  -out ./credentials/admin.crt -days 3653
+
+export ADMIN_CERT=$(cat ./credentials/admin.crt | base64 -w 0)
+export ADMIN_KEY=$(cat ./credentials/admin.key | base64 -w 0)
+export CA_CERT=$(cat ./credentials/ca.crt | base64 -w 0)
+
+echo "apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: ${K8S_ENDPOINT}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: kubernetes-admin
+  name: kubernetes-admin@kubernetes
+current-context: kubernetes-admin@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+  user:
+    client-certificate-data: ${ADMIN_CERT}
+    client-key-data: ${ADMIN_KEY}" > _admin.conf


### PR DESCRIPTION
This script generates _admin.conf for accessing a kubernetes cluster.
Takes the following two optional and one mandatory inputs. 
optional: ca.crt and ca.key
mandatory: endpoint
