### PR TITLE
CI test automation script for KubeadmConfig commands to be mutated

### DIFF
--- a/upgrade_tests/controlplane_upgrade/1cp_1w_kubeadm_update.sh
+++ b/upgrade_tests/controlplane_upgrade/1cp_1w_kubeadm_update.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+source ../common.sh
+
+echo '' > ~/.ssh/known_hosts
+
+set_number_of_node_replicas 2
+provision_controlplane_node
+
+NAMESPACE=${NAMESPACE:-"metal3"}
+CLUSTER_NAME=$(kubectl get clusters -n "${NAMESPACE}" | grep Provisioned | cut -f1 -d' ')
+
+wait_for_ctrlplane_provisioning_start
+
+ORIGINAL_NODE_LIST=$(kubectl get bmh -n "${NAMESPACE}" | grep control | grep -v ready | cut -f1 -d' ')
+echo "BareMetalHosts ${ORIGINAL_NODE_LIST} are in provisioning or provisioned state"
+
+NODE_IP_LIST=()
+for node in "${ORIGINAL_NODE_LIST[@]}";do
+    NODE_IP_LIST+=$(sudo virsh net-dhcp-leases baremetal | grep "${node}"  | awk '{{print $5}}' | cut -f1 -d\/)
+done
+echo "NODE_IP_LIST ${NODE_IP_LIST[@]}"
+wait_for_ctrlplane_provisioning_complete ${ORIGINAL_NODE_LIST[@]} ${NODE_IP_LIST[@]}
+
+kubectl get kcp -n "${NAMESPACE}" -oyaml | sed "s/release\/v1.18.0\/bin/release\/v1.18.1\/bin/g" | kubectl replace -f -
+
+if [ $? -eq 0 ]; then
+    echo "Mutating KubeadmControlPlane is succeeded"
+else
+    echo "Mutating KubeadmControlPlane is failed"
+fi
+
+wait_for_ug_process_to_complete
+
+wait_for_orig_node_deprovisioned

--- a/upgrade_tests/upgrade.sh
+++ b/upgrade_tests/upgrade.sh
@@ -13,6 +13,7 @@ pushd "${M3PATH}/scripts/feature_tests/upgrade/upgrade_tests"
 ./controlplane_upgrade/3cp_0w_bootDiskImage_extraNode_upgrade.sh
 ./controlplane_upgrade/3cp_0w_k8sVer_extraNode_upgrade.sh
 ./controlplane_upgrade/3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
+./controlplane_upgrade/1cp_1w_kubeadm_update.sh
 popd
 
 # Run cluster level ugprade tests


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR adds automation test script for when KubeadmConfig commands need to be changed / users should be able to update KubeadmConfig commands during the upgrade, this PR is needed to automate manual testing of the upgrade process of kcp.