### PR TITLE
Upgrade test failure handling improved

### DIFF
--- a/upgrade_tests/1cp_1w_bootDiskImage_cluster_upgrade.sh
+++ b/upgrade_tests/1cp_1w_bootDiskImage_cluster_upgrade.sh
@@ -36,6 +36,8 @@ for i in {1..3600};do
 	  sleep 1
 	  if [[ "${i}" -ge 3600 ]];then
 		  echo "Error: provisioning of a worker node took too long to start"
+      deprovision_cluster
+      wait_for_cluster_deprovisioned
 		  exit 1
     fi
 	  continue
@@ -59,6 +61,8 @@ for i in {1..3600};do
   echo "Waiting for worker to join the cluster"
   if [[ "${i}" -ge 3600 ]]; then
 	  echo "Error: It took too long for a worker to join the cluster"
+    deprovision_cluster
+    wait_for_cluster_deprovisioned
 	  exit 1
   fi
 done
@@ -110,6 +114,8 @@ for i in {1..3600};do
   echo "Waiting for completion of provisioning of new controlplane and worker nodes"
   if [[ "${i}" -ge 3600 ]]; then
 		  echo "Error: Provisioning of new controlplane and worker nodes too too long to start"
+      deprovision_cluster
+      wait_for_cluster_deprovisioned
 		  exit 1
   fi
   sleep 5
@@ -139,6 +145,8 @@ for i in {1..3600};do
   sleep 5
   if [[ "${i}" -ge 3600 ]];then
 		  echo "Error: It took too long for upgraded worker to join the new cluster"
+      deprovision_cluster
+      wait_for_cluster_deprovisioned
 		  exit 1
   fi
 done
@@ -155,6 +163,8 @@ for i in {1..3600};do
   sleep 5
   if [[ "${i}" -ge 3600 ]];then
 		  echo "Error: deprovisioning of the original controlplane and worker nodes took too long"
+      deprovision_cluster
+      wait_for_cluster_deprovisioned
 		  exit 1
   fi
 done

--- a/upgrade_tests/workers_upgrade/1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
+++ b/upgrade_tests/workers_upgrade/1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
@@ -60,6 +60,8 @@ for i in {1..3600};do
       echo -n "-"	  
       if [[ "${i}" -ge 3600 ]];then
         echo "Error: Upgrade on some or all worker nodes did not start in time"
+        deprovision_cluster
+        wait_for_cluster_deprovisioned
         exit 1
       fi
       sleep 5
@@ -83,6 +85,8 @@ for i in {1..3600};do
     sleep 5
     if [[ "${i}" -ge 3600 ]];then
           echo "Error: Upgraded worker node did not join the cluster in time"
+          deprovision_cluster
+          wait_for_cluster_deprovisioned
           exit 1
     fi
 done
@@ -123,6 +127,8 @@ for i in {1..1800};do
     sleep 5
     if [[ "${i}" -ge 1800 ]];then
         echo "Error: Workload failed to be deployed on the cluster"
+        deprovision_cluster
+        wait_for_cluster_deprovisioned
         exit 1
     fi
 done
@@ -155,6 +161,8 @@ for i in {1..3600};do
   NEW_CP_NODE=$(kubectl get bmh -n metal3 | grep ${new_cp_metal3MachineTemplate_name} | awk '{{print $1}}')
     if [[ "${i}" -ge 3600 ]]; then
 		  echo "Error: Upgrade of controlplane node took too long to start"
+      deprovision_cluster
+      wait_for_cluster_deprovisioned
 		  exit 1
   fi
   if [ -z "$NEW_CP_NODE" ]; then


### PR DESCRIPTION
If a test script fails due to timeout,
deprovision cluster and continue to the next test.