### PR TITLE
Upgrade test script updates

### DIFF
--- a/upgrade_tests/1cp_1w_bootDiskImage_cluster_upgrade.sh
+++ b/upgrade_tests/1cp_1w_bootDiskImage_cluster_upgrade.sh
@@ -5,7 +5,7 @@ set -x
 source ./common.sh
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 set_number_of_worker_node_replicas 1
@@ -132,7 +132,7 @@ for i in {1..3600};do
 done
 
 echo "Boot disk upgrade of both controlplane and worker nodes has succeeded."
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/common.sh
+++ b/upgrade_tests/common.sh
@@ -75,7 +75,7 @@ function wait_for_cluster_deprovisioned() {
             if [[ "${ready_bmhs}" -eq "4" ]];then
                 echo ''
                 echo "Successfully deprovisioned the cluster"
-                exit 0
+                break
             fi
         else
             echo -n "-"
@@ -95,7 +95,7 @@ function wait_for_ctrlplane_provisioning_start() {
                 echo "Error: provisioning took too long to start"
                 deprovision_cluster
                 wait_for_cluster_deprovisioned
-                exit 1
+                break
             fi
             continue
         else
@@ -116,7 +116,7 @@ function wait_for_ctrlplane_provisioning_start() {
                     echo "Error: provisioning took too long to start"
                     deprovision_cluster
                     wait_for_cluster_deprovisioned
-                    exit 1
+                    break
                 fi
             fi
         done
@@ -187,7 +187,7 @@ function wait_for_worker_provisioning_start() {
             echo "Error: provisioning took too long to start"
             deprovision_cluster
             wait_for_cluster_deprovisioned
-            exit 1
+            break
         fi
         continue
     else
@@ -212,7 +212,7 @@ function wait_for_worker_provisioning_complete() {
                 echo "Error: provisioning took too long to start"
                 deprovision_cluster
                 wait_for_cluster_deprovisioned
-                exit 1
+                break
             fi
         else
             break
@@ -257,7 +257,7 @@ function wait_for_ug_process_to_complete() {
                 echo "Upgrade failed, resource(s) are hanging."
                 deprovision_cluster
                 wait_for_cluster_deprovisioned
-                exit 1
+                break
             fi
     done
 
@@ -300,7 +300,7 @@ function wait_for_worker_ug_process_to_complete() {
                 echo "Error: Upgrade on some or all worker nodes did not start in time"
                 deprovision_cluster
                 wait_for_cluster_deprovisioned
-                exit 1
+                break
             fi
             sleep 5
             continue
@@ -325,7 +325,7 @@ function wait_for_worker_ug_process_to_complete() {
             echo "Error: Upgraded worker node did not join the cluster in time"
             deprovision_cluster
             wait_for_cluster_deprovisioned
-            exit 1
+            break
         fi
     done
     echo "Successfully upgraded multiple workers"
@@ -359,7 +359,7 @@ function wait_for_orig_node_deprovisioned() {
                 echo "Error: deprovisioning of original node too too long to complete"
                 deprovision_cluster
                 wait_for_cluster_deprovisioned
-                exit 1
+                break
             fi
         done
     else
@@ -399,7 +399,7 @@ function wait_for_node_to_scale_to {
             echo "Error: Scaling of ${node_type} nodes took to long"
             deprovision_cluster
             wait_for_cluster_deprovisioned
-            exit 1
+            break
         fi
     done
 }
@@ -441,7 +441,7 @@ for i in {1..1800};do
         echo "Error: Workload failed to be deployed on the cluster"
         deprovision_cluster
         wait_for_cluster_deprovisioned
-        exit 1
+        break
     fi
 done
 }

--- a/upgrade_tests/controlplane_upgrade/1cp_0w_bootDiskImage_extraNode_upgrade.sh
+++ b/upgrade_tests/controlplane_upgrade/1cp_0w_bootDiskImage_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 
@@ -38,7 +38,7 @@ wait_for_ug_process_to_complete
 wait_for_orig_node_deprovisioned master 1
 
 echo "Upgrade of OS Image of controlplane node succeeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/controlplane_upgrade/1cp_0w_k8sVer_bootDiskImage_extraNode_upgrade.sh
+++ b/upgrade_tests/controlplane_upgrade/1cp_0w_k8sVer_bootDiskImage_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 
@@ -49,7 +49,7 @@ wait_for_ug_process_to_complete
 wait_for_orig_node_deprovisioned master 1
 
 echo "Upgrading a control plane node image and k8s version from ${FROM_VERSION} to ${TO_VERSION} in cluster ${CLUSTER_NAME} has succeeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/controlplane_upgrade/1cp_0w_k8sVer_extraNode_upgrade.sh
+++ b/upgrade_tests/controlplane_upgrade/1cp_0w_k8sVer_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 
@@ -40,7 +40,7 @@ wait_for_ug_process_to_complete
 wait_for_orig_node_deprovisioned master 1
 
 echo "Upgrading a single control plane nodes k8s version with extra nodes has succeeded."
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/controlplane_upgrade/1cp_1w_kubeadm_update.sh
+++ b/upgrade_tests/controlplane_upgrade/1cp_1w_kubeadm_update.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 set_number_of_worker_node_replicas 1
@@ -41,7 +41,7 @@ wait_for_ug_process_to_complete
 wait_for_orig_node_deprovisioned master_and_worker 2
 
 echo "Mutation of kubeadm data has succeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/controlplane_upgrade/3cp_0w_bootDiskImage_extraNode_upgrade.sh
+++ b/upgrade_tests/controlplane_upgrade/3cp_0w_bootDiskImage_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 # Old name does not matter
 export new_cp_metal3MachineTemplate_name="test1-new-controlplane-image"
@@ -46,7 +46,7 @@ kubectl get kcp -n metal3 test1 -o json | jq '.spec.infrastructureTemplate.name=
 wait_for_ug_process_to_complete
 
 wait_for_orig_node_deprovisioned
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/controlplane_upgrade/3cp_0w_k8sVer_extraNode_upgrade.sh
+++ b/upgrade_tests/controlplane_upgrade/3cp_0w_k8sVer_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 3
 
@@ -44,7 +44,7 @@ wait_for_ug_process_to_complete
 wait_for_orig_node_deprovisioned
 
 echo "Upgrading a control plane nodes k8s version from ${FROM_VERSION} to ${TO_VERSION} in cluster ${CLUSTER_NAME}, has succeeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/upgrade.sh
+++ b/upgrade_tests/upgrade.sh
@@ -24,29 +24,34 @@ popd
 
 cp -r /tmp/airship-dev-tools/upgrade_tests ${M3_DIR}/scripts/feature_tests/upgrade
 
+# -----------------------------------------
+# Syntax:
+# source <script name>.sh <log file prefix>
+# -----------------------------------------
+
 # Run controlplane upgrade tests
 pushd "${M3_DIR}/scripts/feature_tests/upgrade/upgrade_tests/controlplane_upgrade"
-#./1cp_0w_bootDiskImage_extraNode_upgrade.sh
-#./1cp_0w_k8sBin_extraNode_upgrade.sh
-#./1cp_0w_k8sVer_bootDiskImage_extraNode_upgrade.sh
-#./1cp_0w_k8sVer_extraNode_upgrade.sh
-#./1cp_1w_kubeadm_update.sh
-#./3cp_0w_bootDiskImage_extraNode_upgrade.sh
-#./3cp_0w_k8sVer_extraNode_upgrade.sh
-source 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh
+# source 1cp_0w_bootDiskImage_extraNode_upgrade.sh 1cp_0w_bootDiskImage_extraNode_upgrade
+# source 1cp_0w_k8sBin_extraNode_upgrade.sh 1cp_0w_k8sBin_extraNode_upgrade
+# source 1cp_0w_k8sVer_bootDiskImage_extraNode_upgrade.sh 1cp_0w_k8sVer_bootDiskImage_extraNode_upgrade
+# source 1cp_0w_k8sVer_extraNode_upgrade.sh 1cp_0w_k8sVer_extraNode_upgrade
+# source 1cp_1w_kubeadm_update.sh 1cp_1w_kubeadm_update
+# source 3cp_0w_bootDiskImage_extraNode_upgrade.sh 3cp_0w_bootDiskImage_extraNode_upgrade
+# source 3cp_0w_k8sVer_extraNode_upgrade.sh 3cp_0w_k8sVer_extraNode_upgrade
+source 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade.sh 3cp_1w_k8sVer_bootDiskImage_scaleInWorker_upgrade
 popd
 
 # Run cluster level ugprade tests
 pushd "${M3_DIR}/scripts/feature_tests/upgrade/upgrade_tests"
-source 1cp_1w_bootDiskImage_cluster_upgrade.sh
+source 1cp_1w_bootDiskImage_cluster_upgrade.sh 1cp_1w_bootDiskImage_cluster_upgrade
 popd
 
 # Run worker upgrade cases
 pushd "${M3_DIR}/scripts/feature_tests/upgrade/upgrade_tests/workers_upgrade"
-#./1cp_1w_bootDiskImage_extraNode_upgrade.sh
-#./1cp_1w_bootDiskImage_scaleOutWorkers_upgrade.sh
-source 1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
-#./1cp_3w_bootDiskImage_scaleInWorkers_upgrade.sh
+# source 1cp_1w_bootDiskImage_extraNode_upgrade.sh 1cp_1w_bootDiskImage_extraNode_upgrade
+# source 1cp_1w_bootDiskImage_scaleOutWorkers_upgrade.sh 1cp_1w_bootDiskImage_scaleOutWorkers_upgrade
+source 1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh 1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both
+# source 1cp_3w_bootDiskImage_scaleInWorkers_upgrade.sh 1cp_3w_bootDiskImage_scaleInWorkers_upgrade
 popd
 
 # clean up the copied directories

--- a/upgrade_tests/workers_upgrade/1cp_1w_bootDiskImage_extraNode_upgrade.sh
+++ b/upgrade_tests/workers_upgrade/1cp_1w_bootDiskImage_extraNode_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 set_number_of_master_node_replicas 1
 set_number_of_worker_node_replicas 1
@@ -80,7 +80,7 @@ for i in {1..3600};do
 done
 
 echo "Upgrade of OS Image of worker node succeeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/workers_upgrade/1cp_1w_bootDiskImage_scaleOutWorkers_upgrade.sh
+++ b/upgrade_tests/workers_upgrade/1cp_1w_bootDiskImage_scaleOutWorkers_upgrade.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 # Old name does not matter
 export new_wr_metal3MachineTemplate_name="test1-new-workers-image"
@@ -84,7 +84,7 @@ for i in {1..3600};do
 done
 
 echo "Successfully upgraded multiple workers with NO extra node"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned

--- a/upgrade_tests/workers_upgrade/1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
+++ b/upgrade_tests/workers_upgrade/1cp_3w_bootDiskImage_scaleInWorkers_upgrade_both.sh
@@ -6,7 +6,7 @@ source ../common.sh
 
 echo '' > ~/.ssh/known_hosts
 
-start_logging "${0}"
+start_logging "${1}"
 
 # Old name does not matter
 export new_wr_metal3MachineTemplate_name="test1-new-workers-image"
@@ -33,7 +33,7 @@ W_NODE_IP=$(sudo virsh net-dhcp-leases baremetal | grep "${W_NODE}"  | awk '{{pr
 wait_for_worker_provisioning_complete 2 "${W_NODE}" "${W_NODE_IP}" "Worker node"
 
 set_number_of_worker_node_replicas 3
-wait_for_node_to_scale_to 3 "${CP_NODE_IP}" "worker"
+wait_for_node_to_scale_to 3 ${CP_NODE_IP} "worker"
 
 echo "Create a new metal3MachineTemplate with new node image for worker nodes"
 wr_Metal3MachineTemplate_OUTPUT_FILE="/tmp/wr_new_image.yaml"
@@ -53,7 +53,7 @@ wait_for_worker_ug_process_to_complete "${CP_NODE_IP}" "${new_wr_metal3MachineTe
 deploy_workload_on_workers
 
 set_number_of_worker_node_replicas 2
-wait_for_node_to_scale_to 2 "${CP_NODE_IP}" "worker"
+wait_for_node_to_scale_to 2 ${CP_NODE_IP} "worker"
 
 # upgrade a Controlplane
 echo "Create a new metal3MachineTemplate with new node image for both controlplane node"
@@ -86,10 +86,10 @@ for i in {1..3600};do
 done
 
 set_number_of_worker_node_replicas 3
-wait_for_node_to_scale_to 3 "${CP_NODE_IP}" "worker"
+wait_for_node_to_scale_to 3 ${NEW_CP_NODE_IP} "worker"
 
 echo "Upgrading of both (1M + 3W) using scaling in of workers has succeeded"
-echo "successfully run ${0}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
+echo "successfully run ${1}" >> /tmp/$(date +"%Y.%m.%d_upgrade.result.txt")
 
 deprovision_cluster
 wait_for_cluster_deprovisioned


### PR DESCRIPTION
-upgrade.sh script calls changed from './' to
'source' which impacted the logging prefix.
-small fixes to cluster deprovisioning and
control plane ip discovery after an upgrade