### PR TITLE
Fix for minikube delete command

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -5,6 +5,7 @@ set -uex
 DEPLOY_METAL3="${1:-false}"
 
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
+USER="$(whoami)"
 
 # Metal3 Dev Env variables
 M3_DENV_ORG="${M3_DENV_ORG:-metal3-io}"
@@ -45,8 +46,7 @@ if [[ "${DEPLOY_METAL3}" == "true" ]]; then
   git checkout "${M3_DENV_BRANCH}"
   git pull -r || true
   make install_requirements
-  sudo minikube stop
-  sudo minikube delete
+  sudo su -l -c "minikube delete" "${USER}"
   for veth in $(ifconfig | grep -w "provisioning" | grep -w "baremetal"); do ifconfig $veth delete; done
   popd
 


### PR DESCRIPTION
Possible fix for below pasted minikube stop error from CI. As it seen below, minikube will be stopped already, but with this patch we try to delete minikube following the same format as minikube stop:
```
`+ sudo su -l -c 'minikube stop' ****
* Stopping "minikube" in kvm2 ...
* Node "minikube" stopped.
++ sudo virsh domiflist minikube
+ MINIKUBE_IFACES='Interface  Type       Source     Model       MAC
-------------------------------------------------------
-          network    default    virtio      c0:d4:fe:03:b3:27
-          network    minikube-net virtio      94:51:0f:21:1b:26'
+ echo 'Interface  Type       Source     Model       MAC
-------------------------------------------------------
-          network    default    virtio      c0:d4:fe:03:b3:27
-          network    minikube-net virtio      94:51:0f:21:1b:26'
+ grep -w provisioning
+ sudo virsh attach-interface --domain minikube --model virtio --source provisioning --type network --config
Interface attached successfully

+ grep -w baremetal
+ echo 'Interface  Type       Source     Model       MAC
-------------------------------------------------------
-          network    default    virtio      c0:d4:fe:03:b3:27
-          network    minikube-net virtio      94:51:0f:21:1b:26'
+ sudo virsh attach-interface --domain minikube --model virtio --source baremetal --type network --config
Interface attached successfully

+ sudo minikube stop
sudo: minikube: command not found`
```