### PR TITLE
Remove centos volume building from CI

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -183,42 +183,5 @@ pipeline {
         }
       }
     }
-    stage('Building Metal3 CentOS volume'){
-      options {
-        timeout(time: 60, unit: 'MINUTES')
-      }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-            
-            /* Generate Metal3 CentOS dev-env volume */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_centos_volume.sh \
-              /data/id_rsa_airshipci 1"
-          }
-        }
-      }
-      post {
-        always {
-          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-
-            /* Clean up Metal3 CentOS dev-env volume */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/cleanup_volume.sh \
-              /data/id_rsa_airshipci 1"
-            }
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
This PR removes volume building for Centos and leaves building Ubuntu for now, until maybe we find a way out to solve an issue with building Centos volumes. 