### PR TITLE
Fix condition checking when volume status contains an error substring

### DIFF
--- a/ci/images/gen_metal3_centos_volume.sh
+++ b/ci/images/gen_metal3_centos_volume.sh
@@ -44,7 +44,7 @@ do
   sleep 10
   # Check if volume creation is failed
   if [[ "$(openstack volume show "${BUILDER_VOLUME_NAME}" -f json \
-    | jq .status)" == "error" ]];
+    | jq .status)" == *"error"* ]];
   then
     echo "Volume creation is failed"
     # If volume creation is failed, then retry volume creation only once

--- a/ci/images/gen_metal3_ubuntu_volume.sh
+++ b/ci/images/gen_metal3_ubuntu_volume.sh
@@ -44,7 +44,7 @@ do
   sleep 10
   # Check if volume creation is failed
   if [[ "$(openstack volume show "${BUILDER_VOLUME_NAME}" -f json \
-    | jq .status)" == "error" ]];
+    | jq .status)" == *"error"* ]];
   then
     echo "Volume creation is failed"
     # If volume creation is failed, then retry volume creation only once


### PR DESCRIPTION
When creating a volume, volume might go into error status and stay there due to the improper condition check. This PR fixes that, by checking if volume status contains the substring error. 