### PR TITLE
Fix lint image Dockerfile

### DIFF
--- a/resources/docker/linter/Dockerfile
+++ b/resources/docker/linter/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.10
+FROM alpine:latest
 
 RUN apk update && \
     apk add --no-cache ruby ruby-json && \
-    gem install --no-rdoc --no-ri mdl && \
+    gem install --no-document mdl && \
     mkdir /data
 
 WORKDIR /data


### PR DESCRIPTION
The current image being old is suffering from errors like 

```
Error installing mdl:
	The last version of chef-utils (>= 0) to support your Ruby & RubyGems was 16.6.14. Try installing it with `gem install chef-utils -v 16.6.14` and then running the current command again
	chef-utils requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```
This PR fixes the issue. 