### PR TITLE
Export artifactory credentials correctly in node image pipeline

### DIFF
--- a/ci/jobs/openstack_node_image_building.pipeline
+++ b/ci/jobs/openstack_node_image_building.pipeline
@@ -26,6 +26,8 @@ pipeline {
       --env AIRSHIP_CI_USER_KEY=/data/id_rsa_airshipci \
       --env VM_KEY \
       --env RT_URL \
+      --env RT_TOKEN \
+      --env RT_USER \
       --env OS_AUTH_URL \
       --env OS_USER_DOMAIN_NAME \
       --env OS_PROJECT_DOMAIN_NAME \

--- a/ci/scripts/image_scripts/upload_node_image_rt.sh
+++ b/ci/scripts/image_scripts/upload_node_image_rt.sh
@@ -36,6 +36,3 @@ DST_PATH="airship/images/k8s_${KUBERNETES_VERSION}/${IMAGE_NAME}"
 #   RT_URL: Artifactory URL
 
 rt_upload_artifact  "${SOURCE_PATH}" "${DST_PATH}" "0"
-
-# Delete the image from local work directory
-sudo rm -r ${WORK_DIR}


### PR DESCRIPTION
This PR exports artifactory credentials correctly in node image pipeline.