### PR TITLE
Fix docker version to 1.19.3 Ubuntu

### DIFF
--- a/ci/scripts/image_scripts/setup_docker_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_docker_ubuntu.sh
@@ -14,7 +14,7 @@ sudo add-apt-repository -y \
    $(lsb_release -cs) \
    stable"
 sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io jq
+sudo apt-get install -y docker-ce=5:19.03.14~3-0~ubuntu-focal docker-ce-cli=5:19.03.14~3-0~ubuntu-focal containerd.io jq
 sudo groupadd docker
 sudo usermod -aG docker "${USER}"
 sudo systemctl enable docker


### PR DESCRIPTION
With newest docker verion i.e. 20.10 kubeadm init is failing for node
images