### PR TITLE
Fix docker installation in Ubuntu Node image

### DIFF
--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -28,23 +28,21 @@ sudo apt install -y \
   software-properties-common \
   openssl
 
-# Install docker.
-"${SCRIPTS_DIR}"/setup_docker_ubuntu.sh
-
 sudo mv $SCRIPTS_DIR/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo apt-get install -y conntrack socat
 sudo apt install net-tools gcc linux-headers-$(uname -r) bridge-utils apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
 sudo apt install -y keepalived && sudo systemctl stop keepalived
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo bash -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
 sudo apt update -y
+# Install docker.
+"${SCRIPTS_DIR}"/setup_docker_ubuntu.sh 
 echo  "Installing kubernetes binaries"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
 sudo chmod a+x kubeadm kubelet kubectl
 sudo mv kubeadm kubelet kubectl /usr/local/bin/
+sudo apt-mark hold kubelet kubeadm kubectl
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service /etc/systemd/system/kubelet.service
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
Docker installation 19.03.14 is not working properly. This commit tries
to do few tricks to test it.