### PR TITLE
Remove unnecessary code pieces

### DIFF
--- a/ci/images/image_builder_template.json
+++ b/ci/images/image_builder_template.json
@@ -19,7 +19,6 @@
     "source_image": "{{user `source_image`}}",
     "user_data_file": "{{user `user_data_file`}}",
     "flavor":  "{{user `flavor`}}",
-    "volume_size": "20",
     "reuse_ips": false,
     "ssh_keypair_name": "airshipci-key",
     "ssh_private_key_file": "{{user `ssh_private_key_file`}}",

--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -42,7 +42,6 @@ echo  "Installing kubernetes binaries"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
 sudo chmod a+x kubeadm kubelet kubectl
 sudo mv kubeadm kubelet kubectl /usr/local/bin/
-sudo apt-mark hold kubelet kubeadm kubectl
 sudo mkdir -p /etc/systemd/system/kubelet.service.d
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service /etc/systemd/system/kubelet.service
 sudo retrieve.configuration.files.sh https://raw.githubusercontent.com/kubernetes/release/"${KUBERNETES_BINARIES_CONFIG_VERSION}"/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
1. There is no volume build in normal openstack image building, so
volume size is unnecessary
2. We do not need to hold kubelet,kubeadm,kubectl. That was an
experimental code.