### PR TITLE
WIP: Use Kubernetes latest release 1.20

### DIFF
--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -11,7 +11,7 @@ IMAGES_DIR="${CI_DIR}/images"
 SCRIPTS_DIR="${CI_DIR}/scripts/image_scripts"
 OS_SCRIPTS_DIR="${CI_DIR}/scripts/openstack"
 CENTOS_VERSION="8.2"
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.19.3"}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 
 # shellcheck disable=SC1090
 source "${OS_SCRIPTS_DIR}/infra_defines.sh"

--- a/ci/images/gen_node_ubuntu_image.sh
+++ b/ci/images/gen_node_ubuntu_image.sh
@@ -16,7 +16,7 @@ source "${OS_SCRIPTS_DIR}/infra_defines.sh"
 # shellcheck disable=SC1090
 source "${OS_SCRIPTS_DIR}/utils.sh"
 
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.19.3"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 export UBUNTU_VERSION=${UBUNTU_VERSION:-"20.04"}
 
 IMAGE_NAME="${CI_METAL3_IMAGE}-$(get_random_string 10)"

--- a/ci/scripts/image_scripts/install_crio_on_centos.sh
+++ b/ci/scripts/image_scripts/install_crio_on_centos.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -uex
+
+export CRIOCTL_VERSION=${CRICTL_VERSION:-"v1.20.0"}
+OS=${OS:-"CentOS_8"}
+# CRI-O version goes 1:1 with Kubernetes version. Thus,
+# please make sure that k8s version given in
+# KUBERNETES_VERSION variable matches CRI-O version
+# give in VERSION variable.
+VERSION=${VERSION:-"1.20"}
+
+# Create the .conf file to load the modules at bootup
+cat <<EOF | sudo tee /etc/modules-load.d/crio.conf
+overlay
+br_netfilter
+EOF
+
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# Set up required sysctl params, these persist across reboots.
+cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+
+sudo sysctl --system
+
+sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/devel:kubic:libcontainers:stable.repo
+sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$VERSION/$OS/devel:kubic:libcontainers:stable:cri-o:$VERSION.repo
+sudo yum install cri-o -y
+
+sudo systemctl daemon-reload
+sudo systemctl start crio
+
+# Download crictl
+curl -LO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin -xzf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz

--- a/ci/scripts/image_scripts/install_crio_on_ubuntu.sh
+++ b/ci/scripts/image_scripts/install_crio_on_ubuntu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -uex
+
+export CRICTL_VERSION=${CRICTL_VERSION:-"v1.20.0"}
+OS=${OS:-"xUbuntu_20.04"}
+# CRI-O version goes 1:1 with Kubernetes version. Thus,
+# please make sure that k8s version given in
+# KUBERNETES_VERSION variable matches CRI-O version
+# give in VERSION variable.
+VERSION=${VERSION:-"1.20"}
+
+# Prerequisites for CRI-O
+# Create the .conf file to load the modules at bootup
+cat <<EOF | sudo tee /etc/modules-load.d/crio.conf
+overlay
+br_netfilter
+EOF
+
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# Set up required sysctl params, these persist across reboots.
+cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.ipv4.ip_forward                 = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+
+sudo sysctl --system
+
+# Install CRI-O
+cat <<EOF | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /
+EOF
+cat <<EOF | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:$VERSION.list
+deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$VERSION/$OS/ /
+EOF
+
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/libcontainers.gpg add -
+curl -L https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:$VERSION/$OS/Release.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/libcontainers-cri-o.gpg add -
+
+sudo apt-get update
+sudo apt-get install cri-o cri-o-runc -y
+
+# Start CRI-O
+sudo systemctl daemon-reload
+sudo systemctl start crio
+
+# Download crictl
+curl -LO https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin -xzf crictl-${CRICTL_VERSION}-linux-amd64.tar.gz

--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -4,7 +4,7 @@ set -uex
 
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.19.3"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_VERSION}}"
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.2.7"}
 
@@ -31,13 +31,15 @@ sudo apt install -y \
 sudo mv $SCRIPTS_DIR/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo apt-get install -y conntrack socat
-sudo apt install net-tools gcc linux-headers-$(uname -r) bridge-utils apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
+sudo apt install net-tools gcc linux-headers-$(uname -r) bridge-utils -y
 sudo apt install -y keepalived && sudo systemctl stop keepalived
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 sudo bash -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
 sudo apt update -y
-# Install docker.
-"${SCRIPTS_DIR}"/setup_docker_ubuntu.sh 
+
+# Install CRI-O
+"${SCRIPTS_DIR}"/install_crio_on_ubuntu.sh 
+
 echo  "Installing kubernetes binaries"
 curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
 sudo chmod a+x kubeadm kubelet kubectl

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -3,9 +3,12 @@
 set -uex
 
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.19.3"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_VERSION}}"
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.2.7"}
+
+# Install CRI-O
+"${SCRIPTS_DIR}"/install_crio_on_centos.sh 
 
 echo $PATH|tr ':' '\n'
 sudo mv $SCRIPTS_DIR/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
@@ -17,7 +20,6 @@ sudo dnf install python3 -y
 sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 sudo setenforce 0
 sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
-sudo dnf install docker-ce-19.03.14-3.el8 docker-ce-cli-19.03.14-3.el8 --disableexcludes=kubernetes --nobest -y
 sudo dnf install gcc kernel-headers kernel-devel keepalived -y
 sudo dnf install device-mapper-persistent-data lvm2 -y
 echo  \"Installing kubernetes binaries\"

--- a/ci/scripts/image_scripts/upload_node_image_rt.sh
+++ b/ci/scripts/image_scripts/upload_node_image_rt.sh
@@ -8,14 +8,16 @@
 #   2. uploads it to artifactory
 # 
 # Usage:
-#   ./upload_node_image_rt.sh <IMAGE_NAME> <IMAGE_SIZE>
+#   ./upload_node_image_rt.sh <IMAGE_NAME>
 #   ./upload_node_image_rt.sh CENTOS_8.2_NODE_IMAGE_K8S_v1.18.8
+# Don't include the image format, only the name.
+# Example: CENTOS_8.2_NODE_IMAGE_K8S_v1.18.8 instead of CENTOS_8.2_NODE_IMAGE_K8S_v1.18.8.qcow2
 set -x
 IMAGE_NAME="${1:?}"
 
 CI_DIR="$(dirname "$(readlink -f "${0}")")/../.."
 RT_SCRIPTS_DIR="${CI_DIR}/scripts/artifactory"
-export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.19.3"}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.20.0"}
 
 # Download and push the image to artifactory
 WORK_DIR=/tmp/node_image


### PR DESCRIPTION
Install k8s 1.20 binaries on the target node image. Use CRI-O as container runtime for kubelet instead of Docker.