### PR TITLE
Fix calico image var

### DIFF
--- a/ci/scripts/image_scripts/target_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/target_cluster_container_images.sh
@@ -6,7 +6,7 @@ set -uex
 export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.17.1"}"
 export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.17.1"}"
 export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.17.1"}"
-export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_NODE_IMG:-"docker.io/calico/kube-controllers:v3.17.1"}"
+export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_KUBE_CONTROLLERS_IMG:-"docker.io/calico/kube-controllers:v3.17.1"}"
 
 sudo systemctl enable --now crio
 


### PR DESCRIPTION
Fix calico image var

```
  Type     Reason            Age                  From               Message
  ----     ------            ----                 ----               -------
  Warning  FailedScheduling  12m (x3 over 12m)    default-scheduler  0/2 nodes are available: 2 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
  Normal   Scheduled         12m                  default-scheduler  Successfully assigned kube-system/calico-kube-controllers-744cfdf676-97mk9 to test1-54fcf5dd94-kwhd4
  Normal   Pulling           9m16s (x4 over 12m)  kubelet            Pulling image "docker.io/calico/kube-controllers:v3.17.1"
  Warning  Failed            8m42s (x4 over 11m)  kubelet            Failed to pull image "docker.io/calico/kube-controllers:v3.17.1": rpc error: code = Unknown desc = Error reading manifest v3.17.1 in docker.io/calico/kube-controllers: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  Normal   BackOff           8m16s (x6 over 11m)  kubelet            Back-off pulling image "docker.io/calico/kube-controllers:v3.17.1"
  Warning  Failed            6m47s (x5 over 11m)  kubelet            Error: ErrImagePull
  Warning  Failed            2m5s (x27 over 11m)  kubelet            Error: ImagePullBackOff
metal3@test1-kdqzn:~$ sudo crictl images
IMAGE                                 TAG                 IMAGE ID            SIZE
docker.io/calico/cni                  v3.17.1             64e5dfd8d597a       128MB
docker.io/calico/node                 v3.17.1             183b53858d7da       170MB
docker.io/calico/pod2daemon-flexvol   v3.17.1             819d15844f0c9       21.8MB
k8s.gcr.io/coredns                    1.7.0               bfe3a36ebd252       45.4MB
k8s.gcr.io/etcd                       3.4.13-0            0369cf4303ffd       255MB
k8s.gcr.io/kube-apiserver             v1.20.2             a8c2fdb8bf76e       123MB
k8s.gcr.io/kube-controller-manager    v1.20.2             a27166429d98e       117MB
k8s.gcr.io/kube-proxy                 v1.20.2             43154ddb57a83       120MB
k8s.gcr.io/kube-scheduler             v1.20.2             ed2c44fbdd78b       47.6MB
k8s.gcr.io/pause                      3.2                 80d28bedfe5de       688kB
```