### PR TITLE
Bump the Golang version to 1.16

### DIFF
--- a/ci/scripts/image_scripts/source_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/source_cluster_container_images.sh
@@ -5,7 +5,7 @@ set -uex
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME}"
 # Container images that we pre-pull into the CI image.
 export IMG_REGISTRY="${IMG_REGISTRY:-"docker.io/registry:latest"}"
-export IMG_GOLANG_IMG="${IMG_GOLANG_IMG:-"registry.hub.docker.com/library/golang:1.15.3"}"
+export IMG_GOLANG_IMG="${IMG_GOLANG_IMG:-"registry.hub.docker.com/library/golang:1.16"}"
 export IMG_CENTOS_IMG="${IMG_CENTOS_IMG:-"docker.io/centos:centos8"}"
 
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then


### PR DESCRIPTION
Bump the Golang version to [1.16](https://blog.golang.org/go1.16). This is needed to make sure that we download the right version of the Golang container images that will be used in BMO/CAPM3/IPAM repos while building the controller images. This PR should be the last one to merged after.