### PR TITLE
Upgrade calico images

### DIFF
--- a/ci/scripts/image_scripts/target_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/target_cluster_container_images.sh
@@ -3,10 +3,10 @@
 set -uex
 
 # Container images that we pre-pull into the target image.
-export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.17.3"}"
-export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.17.3"}"
-export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.17.3"}"
-export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_KUBE_CONTROLLERS_IMG:-"docker.io/calico/kube-controllers:v3.17.3"}"
+export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.18.0"}"
+export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.18.0"}"
+export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.18.0"}"
+export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_KUBE_CONTROLLERS_IMG:-"docker.io/calico/kube-controllers:v3.18.0"}"
 
 sudo systemctl enable --now crio
 


### PR DESCRIPTION
Upgrade calico images to [v3.18.0](https://github.com/projectcalico/calico/releases/tag/v3.18.0)