### PR TITLE
Download patched kubeadm binary for etcd startup bug in k8s v1.20.4

### DIFF
--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -41,7 +41,14 @@ sudo apt update -y
 "${SCRIPTS_DIR}"/install_crio_on_ubuntu.sh 
 
 echo  "Installing kubernetes binaries"
-curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
+if [[ $KUBERNETES_BINARIES_VERSION != "v1.20.4" ]]; then
+    curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
+else
+    echo "Installing patched kubeadm to workaround etcd startup issue in Kubernetes ${KUBERNETES_BINARIES_VERSION}"
+    echo "https://github.com/kubernetes/kubernetes/issues/99305"
+    curl -L --remote-name -w "-w %{url_effective}" "https://artifactory.nordix.org/artifactory/airship/kubeadm_etcd_patched/k8s_${KUBERNETES_BINARIES_VERSION}/kubeadm"
+    curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubelet,kubectl}"
+fi
 sudo chmod a+x kubeadm kubelet kubectl
 sudo mv kubeadm kubelet kubectl /usr/local/bin/
 sudo mkdir -p /etc/systemd/system/kubelet.service.d

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -25,8 +25,16 @@ sudo setenforce 0
 sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 sudo dnf install gcc kernel-headers kernel-devel keepalived -y
 sudo dnf install device-mapper-persistent-data lvm2 -y
+
 echo  \"Installing kubernetes binaries\"
-curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${KUBERNETES_BINARIES_VERSION}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+if [[ $KUBERNETES_BINARIES_VERSION != "v1.20.4" ]]; then
+    curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}"
+else
+    echo "Installing patched kubeadm to workaround etcd startup issue in Kubernetes ${KUBERNETES_BINARIES_VERSION}"
+    echo "https://github.com/kubernetes/kubernetes/issues/99305"
+    curl -L --remote-name -w "-w %{url_effective}" "https://artifactory.nordix.org/artifactory/airship/kubeadm_etcd_patched/k8s_${KUBERNETES_BINARIES_VERSION}/kubeadm"
+    curl -L --remote-name-all "https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_BINARIES_VERSION}/bin/linux/amd64/{kubelet,kubectl}"
+fi
 chmod a+x kubeadm kubelet kubectl
 sudo mv kubeadm kubelet kubectl /usr/local/bin/
 sudo mkdir -p /etc/systemd/system/kubelet.service.d


### PR DESCRIPTION
I've pushed a patched version of kubeadm v1.20.4 which waits 30 seconds before trying to start etcd to Artifactory. There's no telling how long this bug is going to be around in Kubernetes, so I've amended the image build shell scripts so that we can use our own patched version of kubeadm in affected versions.

Contents of the patch (against kubernetes/kubernetes v1.20.4 tag):
```
diff --git a/cmd/kubeadm/app/phases/etcd/local.go b/cmd/kubeadm/app/phases/etcd/local.go
index 1965e916eed..8e94d0abe27 100644
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -66,6 +66,10 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir, patchesDir string, nodeNa
 		spec = *patchedSpec
 	}
 
+	//Hack: Add a delay of 30 seconds
+	fmt.Printf("[etcd - metal3hack] Delay creation of etcd static manifest to avoid possible race condition\n")
+	time.Sleep(30 * time.Second)
+
 	// writes etcd StaticPod to disk
 	if err := staticpodutil.WriteStaticPodToDisk(kubeadmconstants.Etcd, manifestDir, spec); err != nil {
 		return err
```