### PR TITLE
Renovate bot will automatically assign two people to review a PR

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @kashifest @fmuyassarov @furkatgofurov7 @Xenwar @smoshiur1237 @macaptain @jan-est @namnx228

--- a/renovate.json
+++ b/renovate.json
@@ -45,5 +45,9 @@
       "depNameTemplate": "kubernetes-sigs/cri-tools",
       "datasourceTemplate": "github-tags"
     }
-  ]
+  ],
+  "assigneesFromCodeOwners": true,
+  "assigneesSampleSize": 1,
+  "reviewersFromCodeOwners": true,
+  "reviewersSampleSize": 1
 }


### PR DESCRIPTION
This PR allows the Renovate bot to assign people to review its PR.