### PR TITLE
Disable network manager to prevent it from adding dns entries in /etc…

### DIFF
--- a/ci/images/userdata.tpl
+++ b/ci/images/userdata.tpl
@@ -9,3 +9,5 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
+  - systemctl stop NetworkManager.service
+  - systemctl mask NetworkManager.service


### PR DESCRIPTION
Disable network manager to prevent it from adding dns entries in /etc/resolv.conf