### PR TITLE
Make /etc/resolv.conf immutable

### DIFF
--- a/ci/images/userdata.tpl
+++ b/ci/images/userdata.tpl
@@ -9,3 +9,8 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
+  - echo -e "nameserver 8.8.8.8" > /etc/resolv.conf
+  # Make /etcd/resolv.conf immutable in order to prevent NetworkManager
+  # from overriding DNS entries with values from DHCP servers
+  # This removes network settings of the image building environment from the image.
+  - chattr +i /etc/resolv.conf


### PR DESCRIPTION
Prevents Network Manager from adding nameserver entries in /etc/resolv.conf