### PR TITLE
Move to CentOS stream

### DIFF
--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -10,7 +10,7 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")/.."
 IMAGES_DIR="${CI_DIR}/images"
 SCRIPTS_DIR="${CI_DIR}/scripts/image_scripts"
 OS_SCRIPTS_DIR="${CI_DIR}/scripts/openstack"
-CENTOS_VERSION="8.2"
+CENTOS_VERSION="8"
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.21.1"}
 
 # shellcheck disable=SC1090
@@ -38,7 +38,7 @@ fi
 source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_IMAGE_NAME}-$(get_random_string 10)"
-SOURCE_IMAGE_NAME="ea0091dc-ccb5-401e-bc64-2615321b4087"
+SOURCE_IMAGE_NAME="0e8d7a25-9423-4a14-8dda-15c41fb15d04"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
 SSH_KEYPAIR_NAME="${CI_KEYPAIR_NAME}"

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -23,6 +23,15 @@ sudo yum update -y
 sudo yum update -y curl nss
 sudo yum install -y git make
 
+# Without this minikube cannot start properly kvm and fails.
+# As a simple workaround, this will create an empty file which can 
+# disable the new firmware, more details here [1], look for firmware description.
+# [1] <https://libvirt.org/formatdomain.html#operating-system-booting>
+# upstream commit fixing the behavior to not print error messages for unknown features
+# will be included in RHEL-AV-8.5.0 by next rebase to libvirt 7.4.0.
+sudo mkdir -p /etc/qemu/firmware
+sudo touch /etc/qemu/firmware/50-edk2-ovmf-cc.json
+
 #Install Operator SDK
 OSDK_RELEASE_VERSION=v0.19.0
 curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OSDK_RELEASE_VERSION}/operator-sdk-${OSDK_RELEASE_VERSION}-x86_64-linux-gnu


### PR DESCRIPTION
While running centos integration tests with stream image, minikube is failing to start properly kvm and fails. i.e:

```
+ sudo su -l -c 'minikube start --insecure-registry 192.168.111.1:5000' centos
* minikube v1.20.0 on Centos 8 (kvm/amd64)
* Using the kvm2 driver based on user configuration
X Exiting due to PROVIDER_KVM2_ERROR: /usr/bin/virsh domcapabilities --virttype kvm failed:
error: failed to get emulator capabilities
error: internal error: unknown feature amd-sev-es
exit status 1
* Suggestion: Follow your Linux distribution instructions for configuring KVM
* Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
make: *** [Makefile:4: install_requirements] Error 69
```

To fix or workaround it, simply creating an **empty** file in provisioning centos image script to disable new firmware related issue fixes the problem. Also, this patch points to the new CentOS8 Stream image hash to be used in centos image generate script. 
xref: [bugzilla report](https://bugzilla.redhat.com/show_bug.cgi?id=1961562#c13 )