### PR TITLE
disable requiretty for ubuntu user

### DIFF
--- a/ci/images/ubuntu_userdata.tpl
+++ b/ci/images/ubuntu_userdata.tpl
@@ -9,3 +9,4 @@ users:
 
 runcmd:
   - sed -i "/^127.0.0.1/ s/$/ ${HOSTNAME}/" /etc/hosts
+  - echo "Defaults:ubuntu !requiretty" >> /etc/sudoers

--- a/ci/scripts/image_scripts/hardening_base_image.sh
+++ b/ci/scripts/image_scripts/hardening_base_image.sh
@@ -10,10 +10,11 @@ declare -A ssh_values=(
   [MaxAuthTries]=5
   [Ciphers]="aes128-ctr,aes192-ctr,aes256-ctr"
   [ClientAliveInterval]=900
-  [ClientAliveCountMax]=0
+  [ClientAliveCountMax]=15
   [UsePAM]=yes
   [Protocol]=2
 )
+
 
 # Parameters to secure networking /etc/sysctl.conf
 declare -A network_parameters=(


### PR DESCRIPTION
This PR changes the ssh configuration and sudoers file to bypass issues related to running the e2e tests

Signed-off-by: Anwar Hassen <anwar.hassen@est.tech>