### PR TITLE
✨ Drop CentOS8.3 and move to CentOS Stream

### DIFF
--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -10,7 +10,7 @@ CI_DIR="$(dirname "$(readlink -f "${0}")")/.."
 IMAGES_DIR="${CI_DIR}/images"
 SCRIPTS_DIR="${CI_DIR}/scripts/image_scripts"
 OS_SCRIPTS_DIR="${CI_DIR}/scripts/openstack"
-CENTOS_VERSION="8.3"
+CENTOS_VERSION="8"
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.21.2"}
 
 # shellcheck disable=SC1090
@@ -38,7 +38,7 @@ fi
 source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_IMAGE_NAME}-$(get_random_string 10)"
-SOURCE_IMAGE_NAME="ea0091dc-ccb5-401e-bc64-2615321b4087"
+SOURCE_IMAGE_NAME="0e8d7a25-9423-4a14-8dda-15c41fb15d04"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
 SSH_KEYPAIR_NAME="${CI_KEYPAIR_NAME}"

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -23,6 +23,15 @@ sudo yum update -y
 sudo yum update -y curl nss
 sudo yum install -y git make
 
+# Without this minikube cannot start properly kvm and fails.
+# As a simple workaround, this will create an empty file which can 
+# disable the new firmware, more details here [1], look for firmware description.
+# [1] <https://libvirt.org/formatdomain.html#operating-system-booting>
+# upstream commit fixing the behavior to not print error messages for unknown features
+# will be included in RHEL-AV-8.5.0 by next rebase to libvirt 7.4.0.
+sudo mkdir -p /etc/qemu/firmware
+sudo touch /etc/qemu/firmware/50-edk2-ovmf-cc.json
+
 #Install Operator SDK
 OSDK_RELEASE_VERSION=v0.19.0
 curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${OSDK_RELEASE_VERSION}/operator-sdk-${OSDK_RELEASE_VERSION}-x86_64-linux-gnu

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -17,14 +17,15 @@ echo $PATH|tr ':' '\n'
 sudo mv $SCRIPTS_DIR/node-image-cloud-init/retrieve.configuration.files.sh /usr/local/bin/retrieve.configuration.files.sh
 sudo chmod +x /usr/local/bin/retrieve.configuration.files.sh
 sudo ls -la /usr/local/bin/retrieve.configuration.files.sh
-sudo dnf update -y  
+sudo dnf update -y
 sudo dnf install -y ebtables socat conntrack-tools
 sudo dnf install python3 -y
 sudo dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-sudo setenforce 0
-sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 sudo dnf install gcc kernel-headers kernel-devel keepalived -y
 sudo dnf install device-mapper-persistent-data lvm2 -y
+
+# Disable SELINUX enforcing
+sudo sed -i 's/enforcing/disabled/g' /etc/selinux/config /etc/selinux/config
 
 echo  \"Installing kubernetes binaries\"
 if [[ $KUBERNETES_BINARIES_VERSION != "v1.21.1" && $KUBERNETES_BINARIES_VERSION != "v1.21.0" && $KUBERNETES_BINARIES_VERSION != "v1.20.4" ]]; then


### PR DESCRIPTION
This PR modifies the scripts which are used to build **metal3 centos images** and **centos node images** to be able to drop usage of CentOS 8.3 image in both scripts and replace it with CentOS Stream image. 

As a consequence these are the modifications:

- Image hash pointing to CentOS8.3 located in CityCloud changed to CentOS8 Stream image hash in metal3 centos image generating script. 
- While running centos integration tests with stream image, minikube is failing to start properly kvm and fails. i.e:

```
+ sudo su -l -c 'minikube start --insecure-registry 192.168.111.1:5000' centos
* minikube v1.20.0 on Centos 8 (kvm/amd64)
* Using the kvm2 driver based on user configuration
X Exiting due to PROVIDER_KVM2_ERROR: /usr/bin/virsh domcapabilities --virttype kvm failed:
error: failed to get emulator capabilities
error: internal error: unknown feature amd-sev-es
exit status 1
* Suggestion: Follow your Linux distribution instructions for configuring KVM
* Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/kvm2/
make: *** [Makefile:4: install_requirements] Error 69
```
Creating an **empty** file in provision centos image building script to disable new firmware related issue fixes the problem. 
xref: [bugzilla report](https://bugzilla.redhat.com/show_bug.cgi?id=1961562#c13 )

- When using node image built from CentOS Stream in target cluster, problems with SELINUX has been encountered in serial logs of the nodes, i.e:

```
[   43.639588] cloud-init[1216]: Cloud-init v. 20.3-10.el8_4.3 running 'modules:final' at Mon, 28 Jun 2021 16:13:54 +0000. Up 30.46 seconds.
[   43.639876] cloud-init[1216]: Cloud-init v. 20.3-10.el8_4.3 finished at Mon, 28 Jun 2021 16:14:07 +0000. Datasource DataSourceConfigDrive [net,ver=2][source=/dev/sda2].  Up 43.61 seconds
[   48.137175] cgroup: cgroup: disabling cgroup2 socket matching due to net_prio or net_cls activation
[   48.204682] SELinux: mount invalid.  Same superblock, different security settings for (dev mqueue, type mqueue)
[   59.668681] SELinux: mount invalid.  Same superblock, different security settings for (dev mqueue, type mqueue)
[   60.960533] SELinux: mount invalid.  Same superblock, different security settings for (dev mqueue, type mqueue)
```
Disabling the SELINUX enforcing instead of having it as permissive solved the mount issue. 

**Note:** This is revert of revert (#325 ) with additional changes.