### PR TITLE
Fix CAPI to known working version with CAPO

### DIFF
--- a/capo/README.md
+++ b/capo/README.md
@@ -19,6 +19,9 @@ sudo mv yq_linux_amd64 /usr/local/bin/yq
 * Copy the openstack.rc file for the project you want to use for CAPO
   deployment to /tmp/openstackrc
 
+Note:
+Changes on the CAPI side could break the CAPO setup. In order to avoid that, we are fixing the CAPI version to a known working one, `v0.4.0`. If more recent version is know, please update this document and `configure.sh` script.
+
 Then:
 
 * Run `make` in one tab to bring up a CAPI/CAPO master Kubernetes cluster

--- a/capo/configure.sh
+++ b/capo/configure.sh
@@ -15,6 +15,11 @@ if ! [[ -d "$CAPI_REPO" ]]; then
   echo "Clone this repo from https://github.com/kubernetes-sigs/cluster-api"
   exit 1
 fi
+# use a known working CAPI version
+pushd  "$CAPI_REPO"
+git fetch --all --tags --prune
+git checkout  v0.4.0
+popd
 
 if ! [[ -d "$CAPO_REPO" ]]; then
   echo "Expected to find directory $CAPO_REPO, but couldn't find it."


### PR DESCRIPTION
Due to continuous changes on the CAPI side, some times, the CAPO development environment breaks.
This PR fixes the CAPI version a know working version.