### PR TITLE
Revert calico images to v3.19.1

### DIFF
--- a/ci/scripts/image_scripts/target_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/target_cluster_container_images.sh
@@ -3,10 +3,10 @@
 set -uex
 
 # Container images that we pre-pull into the target image.
-export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.20.0"}"
-export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.20.0"}"
-export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.20.0"}"
-export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_KUBE_CONTROLLERS_IMG:-"docker.io/calico/kube-controllers:v3.20.0"}"
+export CALICO_CNI_IMG="${CALICO_CNI_IMG:-"docker.io/calico/cni:v3.19.1"}"
+export CALICO_POD2DAEMON_IMG="${CALICO_POD2DAEMON_IMG:-"docker.io/calico/pod2daemon-flexvol:v3.19.1"}"
+export CALICO_NODE_IMG="${CALICO_NODE_IMG:-"docker.io/calico/node:v3.19.1"}"
+export CALICO_KUBE_CONTROLLERS_IMG="${CALICO_KUBE_CONTROLLERS_IMG:-"docker.io/calico/kube-controllers:v3.19.1"}"
 
 sudo systemctl enable --now crio
 


### PR DESCRIPTION
Calico has released new images 3.20.0 but the latest manifest they have is still referencing to 3.191. We have pre-downloaded 3.20.0 images because they are available but in metal3-dev-env we are using the latest calico yaml which is pointing to 3.19.1 images.