### PR TITLE
Fix unbound vars in IPA building

### DIFF
--- a/ci/scripts/image_scripts/start_centos_ipa_build.sh
+++ b/ci/scripts/image_scripts/start_centos_ipa_build.sh
@@ -9,6 +9,8 @@ BUILDER_PORT_NAME="${BUILDER_PORT_NAME:-${BUILDER_VM_NAME}-int-port}"
 BUILDER_FLAVOR="${BUILDER_FLAVOR:-2C-8GB}"
 CI_DIR="$(dirname "$(readlink -f "${0}")")"
 IPA_BUILDER_SCRIPT_NAME="${IPA_BUILDER_SCRIPT_NAME:-build_ipa.sh}"
+CI_EXT_NET="airship-ci-ext-net"
+IMAGE_NAME="airship-ci-ubuntu-metal3-img"
 
 # shellcheck disable=SC1090
 source "${CI_DIR}/../openstack/utils.sh"


### PR DESCRIPTION
We have two vars not defined in IPA building scripts, causing the CI to fail.

```
Masking supported pattern matches of $RT_USER or $RT_TOKEN
[Pipeline] {
[Pipeline] sh
+ make build_ipa
/home/****/slave_root/workspace/airship_openstack_ipa_image_building/ci/scripts/image_scripts/start_centos_ipa_build.sh
/home/****/slave_root/workspace/airship_openstack_ipa_image_building/ci/scripts/image_scripts/start_centos_ipa_build.sh: line 20: CI_EXT_NET: unbound variable
/home/****/slave_root/workspace/airship_openstack_ipa_image_building/ci/scripts/image_scripts/start_centos_ipa_build.sh: line 23: IMAGE_NAME: unbound variable
No Port found for ci-builder-vm-20210821120027-int-port
Waiting for the host ci-builder-vm-20210821120027 to come up
/home/****/slave_root/workspace/airship_openstack_ipa_image_building/ci/scripts/image_scripts/../openstack/utils.sh: line 546: 3: parameter null or not set
make: *** [Makefile:145: build_ipa] Error 1
[Pipeline] }
[Pipeline] // withCredentials
[Pipeline] }
```