### PR TITLE
Fix incorrect default path of pinned artifacts

### DIFF
--- a/ci/scripts/image_scripts/artifactory_cleanup.sh
+++ b/ci/scripts/image_scripts/artifactory_cleanup.sh
@@ -9,6 +9,7 @@ RT_URL="https://artifactory.nordix.org/artifactory"
 IPA_ROOT_ARTIFACTORY="airship/images/ipa"
 DRY_RUN="${DRY_RUN:-false}"
 ANONYM="${ANONYM:-0}"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # shellcheck disable=SC1090
 source "${RT_UTILS}"
@@ -19,7 +20,7 @@ CENTOS_STREAM_ROOT="${IPA_ROOT_ARTIFACTORY}/centos/stream"
 
 # Centos Stream Review
 CENTOS_STREAM_REVIEW="${CENTOS_STREAM_ROOT}/review"
-CENTOS_STREAM_REVIEW_PINNED="${PINNED_ARTIFACTS:-/tmp/centos_stream_review_pinned.txt}"
+CENTOS_STREAM_REVIEW_PINNED="${CENTOS_STREAM_REVIEW_PINNED:-${SCRIPT_DIR}/centos_stream_review_pinned.txt}"
 CENTOS_STREAM_REVIEW_RETENTION_NUM="${CENTOS_STREAM_REVIEW_RETENTION_NUM:-5}"
 
 rt_delete_multiple_artifacts "${CENTOS_STREAM_REVIEW}" "${ANONYM}" "${DRY_RUN}" \
@@ -27,7 +28,7 @@ rt_delete_multiple_artifacts "${CENTOS_STREAM_REVIEW}" "${ANONYM}" "${DRY_RUN}" 
 
 # Centos Stream Staging
 CENTOS_STREAM_STAGING="${CENTOS_STREAM_ROOT}/staging"
-CENTOS_STREAM_STAGING_PINNED="${PINNED_ARTIFACTS:-/tmp/centos_stream_staging_pinned.txt}"
+CENTOS_STREAM_STAGING_PINNED="${CENTOS_STREAM_STAGING_PINNED:-${SCRIPT_DIR}/centos_stream_staging_pinned.txt}"
 CENTOS_STREAM_STAGING_RETENTION_NUM="${CENTOS_STREAM_STAGING_RETENTION_NUM:-10}"
 
 rt_delete_multiple_artifacts "${CENTOS_STREAM_STAGING}" "${ANONYM}" "${DRY_RUN}" \


### PR DESCRIPTION
Environment variables that contained the paths to the pinned artifact
lists had incorrect default values.