### PR TITLE
Add atop and sar monitoring tools to images

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image.sh
@@ -65,5 +65,8 @@ fi
 sudo "${CONTAINER_RUNTIME}" images
 sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_config
 
+# Install monitoring tools
+"${SCRIPTS_DIR}"/setup_monitoring_ubuntu.sh
+
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -72,5 +72,8 @@ sudo "${CONTAINER_RUNTIME}" images
 
 sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_config
 
+# Install monitoring tools
+"${SCRIPTS_DIR}"/setup_monitoring_centos.sh
+
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh

--- a/ci/scripts/image_scripts/setup_monitoring_centos.sh
+++ b/ci/scripts/image_scripts/setup_monitoring_centos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Collect monitoring data with atop and sar
+# https://aws.amazon.com/premiumsupport/knowledge-center/ec2-linux-configure-monitoring-tools/
+
+## Install atop and sar
+sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y
+sudo dnf -y install sysstat atop --enablerepo=epel
+
+## Collect all metrics every minute
+sudo sed -i 's/^LOGINTERVAL=600.*/LOGINTERVAL=60/' /etc/sysconfig/atop
+sudo mkdir -v /etc/systemd/system/sysstat-collect.timer.d/
+sudo bash -c "sed -e 's|every 10 minutes|every 1 minute|g' -e '/^OnCalendar=/ s|/10$|/1|' /usr/lib/systemd/system/sysstat-collect.timer > /etc/systemd/system/sysstat-collect.timer.d/override.conf"
+sudo sed -i 's|^SADC_OPTIONS=.*|SADC_OPTIONS=" -S XALL"|' /etc/sysconfig/sysstat
+
+## Reduce metrics retention to 3 days
+sudo sed -i 's/^LOGGENERATIONS=.*/LOGGENERATIONS=3/' /etc/sysconfig/atop
+sudo sed -i 's|^HISTORY=.*|HISTORY=3"|' /etc/sysconfig/sysstat
+
+## Standardize sysstat log directory
+sudo mkdir -p /var/log/sysstat
+sudo sed -i 's|^SA_DIR=.*|SA_DIR="/var/log/sysstat"|' /etc/sysconfig/sysstat
+
+## Enable services
+systemctl enable atop.service crond.service sysstat.service

--- a/ci/scripts/image_scripts/setup_monitoring_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_monitoring_ubuntu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Collect monitoring data with atop and sar
+# https://aws.amazon.com/premiumsupport/knowledge-center/ec2-linux-configure-monitoring-tools/
+
+## Install monitoring tools
+sudo apt-get -y install atop sysstat
+
+## Collect all metrics every minute
+sudo sed -i 's/^LOGINTERVAL=600.*/LOGINTERVAL=60/' /usr/share/atop/atop.daily
+sudo sed -i -e 's|5-55/10|*/1|' -e 's|every 10 minutes|every 1 minute|' -e 's|debian-sa1|debian-sa1 -S XALL|g' /etc/cron.d/sysstat
+sudo bash -c "echo 'SA1_OPTIONS=\"-S XALL\"' >> /etc/default/sysstat"
+
+## Reduce metrics retention to 3 days
+sudo sed -i 's/^LOGGENERATIONS=.*/LOGGENERATIONS=3/' /usr/share/atop/atop.daily
+sudo sed -i 's/^HISTORY=.*/HISTORY=3/' /etc/default/sysstat
+
+## Enable services
+sudo sed -i 's|ENABLED="false"|ENABLED="true"|' /etc/default/sysstat
+sudo systemctl enable atop.service cron.service sysstat.service


### PR DESCRIPTION
Add and configure the atop and sar monitoring tools to images. The tools are configured to run every minute and keep history for 3 days.

atop gives per process CPU, memory, disk and network statistics, while sar will give us overall system level stats.

I estimate for a 6 hour run, the tools will consume about 30 MB of disk space.