### PR TITLE
Fix unbound var in node image building process

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image.sh
@@ -62,7 +62,6 @@ fi
 # Download container images
 "${SCRIPTS_DIR}"/source_cluster_container_images.sh
 
-sudo "${CONTAINER_RUNTIME}" images
 sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_config
 
 # Reset cloud-init to run on next boot.

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -68,8 +68,6 @@ sudo dnf -y install podman
 # Download container images
 "${SCRIPTS_DIR}"/source_cluster_container_images.sh
 
-sudo "${CONTAINER_RUNTIME}" images
-
 sudo sed -i "0,/.*PermitRootLogin.*/s//PermitRootLogin yes/" /etc/ssh/sshd_config
 
 # Reset cloud-init to run on next boot.

--- a/ci/scripts/image_scripts/provision_node_image.sh
+++ b/ci/scripts/image_scripts/provision_node_image.sh
@@ -7,6 +7,7 @@ SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.22.0"}
 export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_VERSION}}"
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.2.7"}
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
 # Upgrade all packages
 sudo apt-get update
@@ -61,8 +62,6 @@ sudo rm "${HOME}"/.ssh/authorized_keys
 
 # Download container images
 "${SCRIPTS_DIR}"/target_cluster_container_images.sh
-
-sudo "${CONTAINER_RUNTIME}" images
 
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh

--- a/ci/scripts/image_scripts/provision_node_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_node_image_centos.sh
@@ -6,6 +6,7 @@ SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.22.0"}
 export KUBERNETES_BINARIES_VERSION="${KUBERNETES_BINARIES_VERSION:-${KUBERNETES_VERSION}}"
 export KUBERNETES_BINARIES_CONFIG_VERSION=${KUBERNETES_BINARIES_CONFIG_VERSION:-"v0.2.7"}
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
 # Install CRI-O
 "${SCRIPTS_DIR}"/install_crio_on_centos.sh
@@ -48,8 +49,6 @@ sudo rm "${HOME}"/.ssh/authorized_keys
 
 # Download container images
 "${SCRIPTS_DIR}"/target_cluster_container_images.sh
-
-sudo "${CONTAINER_RUNTIME}" images
 
 # Reset cloud-init to run on next boot.
 "${SCRIPTS_DIR}"/reset_cloud_init.sh


### PR DESCRIPTION
Node image image building jobs started to fail with CONTAINER_RUNTIME var being unbound.
This patch cleans up unnecessary listing of images and defaults  CONTAINER_RUNTIME to docker&podman for Ubuntu & CentOS respectively.
Example of failed CI job: https://jenkins.nordix.org/job/airship_openstack_node_image_building/95/consoleFull
 