### PR TITLE
Install krew for kubectl plugin installation

### DIFF
--- a/ci/scripts/image_scripts/setup_monitoring_centos.sh
+++ b/ci/scripts/image_scripts/setup_monitoring_centos.sh
@@ -6,6 +6,18 @@
 sudo dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y
 sudo dnf -y install sysstat atop --enablerepo=epel
 
+## Install krew
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+sudo echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> ~/.bashrc
+
 ## Collect all metrics every minute
 sudo sed -i 's/^LOGINTERVAL=600.*/LOGINTERVAL=60/' /etc/sysconfig/atop
 sudo mkdir -v /etc/systemd/system/sysstat-collect.timer.d/

--- a/ci/scripts/image_scripts/setup_monitoring_ubuntu.sh
+++ b/ci/scripts/image_scripts/setup_monitoring_ubuntu.sh
@@ -5,6 +5,19 @@
 ## Install monitoring tools
 sudo apt-get -y install atop sysstat
 
+## Install krew
+(
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+sudo echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> ~/.bashrc 
+
 ## Collect all metrics every minute
 sudo sed -i 's/^LOGINTERVAL=600.*/LOGINTERVAL=60/' /usr/share/atop/atop.daily
 sudo sed -i -e 's|5-55/10|*/1|' -e 's|every 10 minutes|every 1 minute|' -e 's|debian-sa1|debian-sa1 -S XALL|g' /etc/cron.d/sysstat


### PR DESCRIPTION
We need to install [Krew](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) kubectl plugin installed to be able to install [Promdump](https://github.com/ihcsim/promdump) plugin later.   