### PR TITLE
Add kind image v1.21.2 for v1a4 tests

### DIFF
--- a/ci/scripts/image_scripts/source_cluster_container_images.sh
+++ b/ci/scripts/image_scripts/source_cluster_container_images.sh
@@ -10,8 +10,11 @@ export IMG_CENTOS_IMG="${IMG_CENTOS_IMG:-"docker.io/centos:centos8"}"
 
 if [[ "${IMAGE_OS}" == "Ubuntu" ]]; then
     export KUBERNETES_VERSION=${KUBERNETES_VERSION:-"v1.22.0"}
-    export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.22.0"}   
+    export KIND_NODE_IMAGE_VERSION=${KIND_NODE_IMAGE_VERSION:-"v1.22.0"}
+    # Since capm3 v1a4 tests can only survive with k8s < v1.22
+    # the following docker image also needs to be a part of the disk image.
     export IMG_KIND_NODE_IMAGE="${IMG_KIND_NODE_IMAGE:-"kindest/node:${KIND_NODE_IMAGE_VERSION}"}"
+    export IMG_KIND_CAPM3_v1a4="kindest/node:v1.21.2"   
 fi
 
 for container in $(env | grep "IMG_*" | cut -f2 -d'='); do


### PR DESCRIPTION
Since capm3 v1a4 tests can only survive with k8s < v1.22 we also need to prepull kind docker  image version 1.21.2