### PR TITLE
Add KUBERNETES_VERSION var in image building pipeline

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -22,10 +22,12 @@ pipeline {
     OS_TENANT_NAME="Default Project 37137"
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
+    KUBERNETES_VERSION = "${KUBERNETES_VERSION}"
     DOCKER_CMD_ENV="--env AIRSHIP_CI_USER \
       --env AIRSHIP_CI_USER_KEY=/data/id_rsa_airshipci \
       --env VM_KEY \
       --env RT_URL \
+      --env KUBERNETES_VERSION \
       --env OS_AUTH_URL \
       --env OS_USER_DOMAIN_NAME \
       --env OS_PROJECT_DOMAIN_NAME \

--- a/ci/jobs/openstack_node_image_building.pipeline
+++ b/ci/jobs/openstack_node_image_building.pipeline
@@ -22,12 +22,14 @@ pipeline {
     OS_TENANT_NAME="Default Project 37137"
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
+    KUBERNETES_VERSION = "${KUBERNETES_VERSION}"
     DOCKER_CMD_ENV="--env AIRSHIP_CI_USER \
       --env AIRSHIP_CI_USER_KEY=/data/id_rsa_airshipci \
       --env VM_KEY \
       --env RT_URL \
       --env RT_TOKEN \
       --env RT_USER \
+      --env KUBERNETES_VERSION \
       --env OS_AUTH_URL \
       --env OS_USER_DOMAIN_NAME \
       --env OS_PROJECT_DOMAIN_NAME \


### PR DESCRIPTION
Add `KUBERNETES_VERSION` var in image building pipeline so that value is inherited from JJB.
Please **DON"T MERGE** until https://gerrit.nordix.org/c/infra/cicd/+/10487 hasn't landed. 