### PR TITLE
Always run 01 script in image building process

### DIFF
--- a/ci/images/gen_metal3_centos_volume.sh
+++ b/ci/images/gen_metal3_centos_volume.sh
@@ -121,7 +121,7 @@ ssh \
   -i "${SSH_PRIVATE_KEY_FILE}" \
   "${SSH_USER_NAME}"@"${PACKAGE_INSTALLER_VM_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/provision_metal3_image_centos.sh true
+  /tmp/provision_metal3_image_centos.sh
 
 # Delete the floating IP of installer VM
 if [[ "$USE_FLOATING_IP" -ne 1 ]]; then

--- a/ci/images/gen_metal3_ubuntu_volume.sh
+++ b/ci/images/gen_metal3_ubuntu_volume.sh
@@ -123,7 +123,7 @@ ssh \
   -i "${SSH_PRIVATE_KEY_FILE}" \
   "${SSH_USER_NAME}"@"${PACKAGE_INSTALLER_VM_IP}" \
   PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/bin \
-  /tmp/provision_metal3_image.sh true
+  /tmp/provision_metal3_image.sh
 
 # Delete the floating IP of installer VM
 if [[ "$USE_FLOATING_IP" -ne 1 ]]; then

--- a/ci/scripts/image_scripts/provision_metal3_image.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image.sh
@@ -2,8 +2,6 @@
 
 set -uex
 
-DEPLOY_METAL3="${1:-false}"
-
 #Disable the automatic updates
 cat << EOF | sudo tee /etc/apt/apt.conf.d/20auto-upgrades
 APT::Periodic::Update-Package-Lists "0";
@@ -39,25 +37,23 @@ sudo mv operator-sdk-${OSDK_RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/ope
 
 sudo apt install -y git
 
-if [[ "${DEPLOY_METAL3}" == "true" ]]; then
-  ## Install metal3 requirements
-  mkdir -p "${M3_DENV_ROOT}"
-  if [[ -d "${M3_DENV_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
-    sudo rm -rf "${M3_DENV_PATH}"
-  fi
-  if [ ! -d "${M3_DENV_PATH}" ] ; then
-    pushd "${M3_DENV_ROOT}"
-    git clone "${M3_DENV_URL}"
-    popd
-  fi
-  pushd "${M3_DENV_PATH}"
-  git checkout "${M3_DENV_BRANCH}"
-  git pull -r || true
-  make install_requirements
-  popd
-
-  rm -rf "${M3_DENV_PATH}"
+## Install metal3 requirements
+mkdir -p "${M3_DENV_ROOT}"
+if [[ -d "${M3_DENV_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
+  sudo rm -rf "${M3_DENV_PATH}"
 fi
+if [ ! -d "${M3_DENV_PATH}" ] ; then
+  pushd "${M3_DENV_ROOT}"
+  git clone "${M3_DENV_URL}"
+  popd
+fi
+pushd "${M3_DENV_PATH}"
+git checkout "${M3_DENV_BRANCH}"
+git pull -r || true
+make install_requirements
+popd
+
+rm -rf "${M3_DENV_PATH}"
 
 # Download container images
 "${SCRIPTS_DIR}"/source_cluster_container_images.sh

--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -2,8 +2,6 @@
 
 set -uex
 
-DEPLOY_METAL3="${1:-false}"
-
 SCRIPTS_DIR="$(dirname "$(readlink -f "${0}")")"
 
 # Metal3 Dev Env variables
@@ -40,26 +38,24 @@ sudo mkdir -p /usr/local/bin/
 sudo mv operator-sdk-${OSDK_RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk
 
 
-if [[ "${DEPLOY_METAL3}" == "true" ]]; then
-  ## Install metal3 requirements
-  mkdir -p "${M3_DENV_ROOT}"
-  if [[ -d "${M3_DENV_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
-    sudo rm -rf "${M3_DENV_PATH}"
-  fi
-  if [ ! -d "${M3_DENV_PATH}" ] ; then
-    pushd "${M3_DENV_ROOT}"
-    git clone "${M3_DENV_URL}"
-    popd
-  fi
-  pushd "${M3_DENV_PATH}"
-  git checkout "${M3_DENV_BRANCH}"
-  git pull -r || true
-  make install_requirements
-  sudo su -l -c "minikube delete" "${USER}"
-  popd
-
-  rm -rf "${M3_DENV_PATH}"
+## Install metal3 requirements
+mkdir -p "${M3_DENV_ROOT}"
+if [[ -d "${M3_DENV_PATH}" && "${FORCE_REPO_UPDATE}" == "true" ]]; then
+  sudo rm -rf "${M3_DENV_PATH}"
 fi
+if [ ! -d "${M3_DENV_PATH}" ] ; then
+  pushd "${M3_DENV_ROOT}"
+  git clone "${M3_DENV_URL}"
+  popd
+fi
+pushd "${M3_DENV_PATH}"
+git checkout "${M3_DENV_BRANCH}"
+git pull -r || true
+make install_requirements
+sudo su -l -c "minikube delete" "${USER}"
+popd
+
+rm -rf "${M3_DENV_PATH}"
 
 # We need podman in order to
 #pull container images for Centos Jenkins image


### PR DESCRIPTION
The CentOS images currently don't have the 01 script run in them. This means that Docker images are pulled unnecessarily and the build time is prolonged. This is because of a missing 'true' argument when the provisioning script is run.

Previously, cloning metal3 and running the 01 script was gated in the image building process by a variable called DEPLOY_METAL3, which took the first argument the script was run with as a boolean. The provisioning scripts explicitly state that they deploy metal3, so I can't see a purpose for this variable and have removed it to ensure that we consistently run the 01 script from metal3 in our images.