### PR TITLE
Inherit KIND_NODE_IMAGE_VERSION value from JJB

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -23,11 +23,13 @@ pipeline {
     OS_AUTH_VERSION=3
     OS_IDENTITY_API_VERSION=3
     KUBERNETES_VERSION = "${KUBERNETES_VERSION}"
+    KIND_NODE_IMAGE_VERSION = "${KIND_NODE_IMAGE_VERSION}"
     DOCKER_CMD_ENV="--env AIRSHIP_CI_USER \
       --env AIRSHIP_CI_USER_KEY=/data/id_rsa_airshipci \
       --env VM_KEY \
       --env RT_URL \
       --env KUBERNETES_VERSION \
+      --env KIND_NODE_IMAGE_VERSION \
       --env OS_AUTH_URL \
       --env OS_USER_DOMAIN_NAME \
       --env OS_PROJECT_DOMAIN_NAME \


### PR DESCRIPTION
We have added `KIND_NODE_IMAGE_VERSION` to our JJB so that we can manipulate the value while triggering the job. However, this var's value is not inherited in the next scripts because we haven't added it in our jenkins pipeline to fetch it from JJB.
