### PR TITLE
Install EPEL in centos

### DIFF
--- a/ci/scripts/image_scripts/provision_metal3_image_centos.sh
+++ b/ci/scripts/image_scripts/provision_metal3_image_centos.sh
@@ -21,6 +21,9 @@ sudo yum update -y
 sudo yum update -y curl nss
 sudo yum install -y git make
 
+# Install EPEL repo (later required by atop, python3-bcrypt and python3-passlib)
+sudo yum install -y epel-release && sudo yum update -y
+
 # Without this minikube cannot start properly kvm and fails.
 # As a simple workaround, this will create an empty file which can 
 # disable the new firmware, more details here [1], look for firmware description.


### PR DESCRIPTION
This is required by the python3-bcrypt and python3-passlib packages now that we trigger the 01 script in the image building process.