### PR TITLE
Update image build scripts

### DIFF
--- a/ci/images/gen_base_ubuntu_image.sh
+++ b/ci/images/gen_base_ubuntu_image.sh
@@ -18,7 +18,7 @@ source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_BASE_IMAGE}-$(get_random_string 10)"
 FINAL_IMAGE_NAME="${CI_BASE_IMAGE}"
-SOURCE_IMAGE="dba1e718-a102-46be-b8e9-ae1b1f2fd2fb"
+SOURCE_IMAGE_NAME="Ubuntu-20.04"
 IMAGE_FLAVOR="1C-4GB-20GB"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
@@ -28,6 +28,7 @@ FLOATING_IP_NETWORK="$( [ "${USE_FLOATING_IP}" = 1 ] && echo "${EXT_NET}")"
 REMOTE_EXEC_CMD="KUBERNETES_VERSION=${KUBERNETES_VERSION} /home/${SSH_USER_NAME}/image_scripts/provision_base_image.sh"
 SSH_USER_GROUP="sudo"
 
+SOURCE_IMAGE="$(get_resource_id_from_name image "${SOURCE_IMAGE_NAME}")"
 SSH_AUTHORIZED_KEY="$(cat "${OS_SCRIPTS_DIR}/id_rsa_airshipci.pub")"
 render_user_data \
   "${SSH_AUTHORIZED_KEY}" \

--- a/ci/images/gen_metal3_centos_image.sh
+++ b/ci/images/gen_metal3_centos_image.sh
@@ -38,7 +38,7 @@ fi
 source "${OS_SCRIPTS_DIR}/utils.sh"
 
 IMAGE_NAME="${CI_IMAGE_NAME}-$(get_random_string 10)"
-SOURCE_IMAGE_NAME="0e8d7a25-9423-4a14-8dda-15c41fb15d04"
+SOURCE_IMAGE_NAME="CentOS-Stream-GenericCloud-8"
 USER_DATA_FILE="$(mktemp -d)/userdata"
 SSH_USER_NAME="${CI_SSH_USER_NAME}"
 SSH_KEYPAIR_NAME="${CI_KEYPAIR_NAME}"

--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -187,6 +187,31 @@ pipeline {
         }
       }
     }
+    stage('Building base image for Frankfurt region'){
+      options {
+        timeout(time: 30, unit: 'MINUTES')
+      }
+      environment {
+        OS_AUTH_URL="https://fra1.citycloud.com:5000"
+        OS_REGION_NAME="Fra1"
+      }
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+
+            /* Generate base ubuntu image */
+            sh "docker run --rm \
+              ${DOCKER_CMD_ENV}\
+              -v ${CURRENT_DIR}:/data \
+              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+              registry.nordix.org/airship/image-builder \
+              /data/ci/images/gen_base_ubuntu_image.sh \
+              /data/id_rsa_airshipci 1"
+
+          }
+        }
+      }
+    }
     stage('Building Metal3 Ubuntu image for Frankfurt region'){
       options {
         timeout(time: 60, unit: 'MINUTES')


### PR DESCRIPTION
This PR updates the image build scripts to include name instead of id as source image since the id's are different in different region for the same source image. Also, a base image creation is needed for Frankfurt region since metal3 Ubuntu image sources it.