### PR TITLE
Add catchError to stages of node image building pipeline

### DIFF
--- a/ci/jobs/openstack_image_building.pipeline
+++ b/ci/jobs/openstack_image_building.pipeline
@@ -51,37 +51,42 @@ pipeline {
       options {
         timeout(time: 5, unit: 'MINUTES')
       }
-      steps {
-        /* Checkout CI Repo */
-        checkout([$class: 'GitSCM',
-                 branches: [[name: ci_git_branch]],
-                 doGenerateSubmoduleConfigurations: false,
-                 extensions: [[$class: 'WipeWorkspace'],
-                 [$class: 'CleanCheckout'],
-                 [$class: 'CleanBeforeCheckout']],
-                 submoduleCfg: [],
-                 userRemoteConfigs: [[credentialsId: ci_git_credential_id,
-                 url: ci_git_url]]])
-
+      
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed SCM']) {
+        steps {
+          /* Checkout CI Repo */
+          checkout([$class: 'GitSCM',
+                  branches: [[name: ci_git_branch]],
+                  doGenerateSubmoduleConfigurations: false,
+                  extensions: [[$class: 'WipeWorkspace'],
+                  [$class: 'CleanCheckout'],
+                  [$class: 'CleanBeforeCheckout']],
+                  submoduleCfg: [],
+                  userRemoteConfigs: [[credentialsId: ci_git_credential_id,
+                  url: ci_git_url]]])
+           sh "exit 1"
+        }
       }
     }
     stage('Building base image'){
       options {
         timeout(time: 30, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the base image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate base ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_base_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate base ubuntu image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_base_ubuntu_image.sh \
+                /data/id_rsa_airshipci 1"
 
+            }
           }
         }
       }
@@ -90,19 +95,21 @@ pipeline {
       options {
         timeout(time: 30, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Jenkins image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate Jumphost / Jenkins ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_jumphost_jenkins_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate Jumphost / Jenkins ubuntu image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_jumphost_jenkins_ubuntu_image.sh \
+                /data/id_rsa_airshipci 1"
 
+            }
           }
         }
       }
@@ -111,19 +118,21 @@ pipeline {
       options {
         timeout(time: 60, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 Ubuntu image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate Metal3 ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate Metal3 ubuntu image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_ubuntu_image.sh \
+                /data/id_rsa_airshipci 1"
 
+            }
           }
         }
       }
@@ -132,20 +141,22 @@ pipeline {
       options {
         timeout(time: 60, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 CentOS image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate Metal3 CentOS dev-env image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_centos_image.sh \
-              /data/id_rsa_airshipci 1 \
-              provision_metal3_image_centos.sh"
+              /* Generate Metal3 CentOS dev-env image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_centos_image.sh \
+                /data/id_rsa_airshipci 1 \
+                provision_metal3_image_centos.sh"
 
+            }
           }
         }
       }
@@ -154,18 +165,20 @@ pipeline {
       options {
         timeout(time: 60, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-            
-            /* Generate Metal3 ubuntu volume */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_ubuntu_volume.sh \
-              /data/id_rsa_airshipci 1"
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 Ubuntu volume']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+
+              /* Generate Metal3 ubuntu volume */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_ubuntu_volume.sh \
+                /data/id_rsa_airshipci 1"
+            }
           }
         }
       }
@@ -195,19 +208,21 @@ pipeline {
         OS_AUTH_URL="https://fra1.citycloud.com:5000"
         OS_REGION_NAME="Fra1"
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the base image for Frankfurt region']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate base ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_base_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate base ubuntu image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_base_ubuntu_image.sh \
+                /data/id_rsa_airshipci 1"
 
+            }
           }
         }
       }
@@ -220,19 +235,21 @@ pipeline {
         OS_AUTH_URL="https://fra1.citycloud.com:5000"
         OS_REGION_NAME="Fra1"
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 Ubuntu image for Frankfurt region']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate Metal3 ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate Metal3 ubuntu image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_ubuntu_image.sh \
+                /data/id_rsa_airshipci 1"
 
+            }
           }
         }
       }
@@ -245,20 +262,22 @@ pipeline {
         OS_AUTH_URL="https://fra1.citycloud.com:5000"
         OS_REGION_NAME="Fra1"
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 CentOS image for Frankfurt region']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
 
-            /* Generate Metal3 CentOS dev-env image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_centos_image.sh \
-              /data/id_rsa_airshipci 1 \
-              provision_metal3_image_centos.sh"
+              /* Generate Metal3 CentOS dev-env image */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_centos_image.sh \
+                /data/id_rsa_airshipci 1 \
+                provision_metal3_image_centos.sh"
 
+            }
           }
         }
       }
@@ -271,18 +290,20 @@ pipeline {
         OS_AUTH_URL="https://fra1.citycloud.com:5000"
         OS_REGION_NAME="Fra1"
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
-            
-            /* Generate Metal3 ubuntu volume */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_ubuntu_volume.sh \
-              /data/id_rsa_airshipci 1"
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the Metal3 Ubuntu volume for Frankfurt region']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]){
+
+              /* Generate Metal3 ubuntu volume */
+              sh "docker run --rm \
+                ${DOCKER_CMD_ENV}\
+                -v ${CURRENT_DIR}:/data \
+                -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+                registry.nordix.org/airship/image-builder \
+                /data/ci/images/gen_metal3_ubuntu_volume.sh \
+                /data/id_rsa_airshipci 1"
+            }
           }
         }
       }

--- a/ci/jobs/openstack_node_image_building.pipeline
+++ b/ci/jobs/openstack_node_image_building.pipeline
@@ -51,19 +51,23 @@ pipeline {
       options {
         timeout(time: 60, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
-            withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the node Ubuntu image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
+              withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {
 
-            /* Generate node ubuntu image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_node_ubuntu_image.sh \
-              /data/id_rsa_airshipci 1"
+              /* Generate node ubuntu image */
+              sh "exit 1"
+              // sh "docker run --rm \
+              //   ${DOCKER_CMD_ENV}\
+              //   -v ${CURRENT_DIR}:/data \
+              //   -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+              //   registry.nordix.org/airship/image-builder \
+              //   /data/ci/images/gen_node_ubuntu_image.sh \
+              //   /data/id_rsa_airshipci 1"
+              
+              }
             }
           }
         }
@@ -73,20 +77,22 @@ pipeline {
       options {
         timeout(time: 60, unit: 'MINUTES')
       }
-      steps {
-        withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
-          withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
-            withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {
+      catchError([buildResult: 'SUCCESS', stageResult: 'FAILURE', message: 'Failed to build the node CentOS image']) {
+        steps {
+          withCredentials([usernamePassword(credentialsId: 'airshipci_city_cloud_openstack_credentials', usernameVariable: 'OS_USERNAME', passwordVariable: 'OS_PASSWORD')]) {
+            withCredentials([sshUserPrivateKey(credentialsId: 'airshipci_city_cloud_ssh_keypair', keyFileVariable: 'AIRSHIP_CI_USER_KEY')]) {
+              withCredentials([usernamePassword(credentialsId: 'infra-nordix-artifactory-api-key', usernameVariable: 'RT_USER', passwordVariable: 'RT_TOKEN')]) {
 
-            /* Generate node CentOS dev-env image */
-            sh "docker run --rm \
-              ${DOCKER_CMD_ENV}\
-              -v ${CURRENT_DIR}:/data \
-              -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
-              registry.nordix.org/airship/image-builder \
-              /data/ci/images/gen_metal3_centos_image.sh \
-              /data/id_rsa_airshipci 1 \
-              provision_node_image_centos.sh"
+              /* Generate node CentOS dev-env image */
+              // sh "docker run --rm \
+              //   ${DOCKER_CMD_ENV}\
+              //   -v ${CURRENT_DIR}:/data \
+              //   -v ${AIRSHIP_CI_USER_KEY}:/data/id_rsa_airshipci \
+              //   registry.nordix.org/airship/image-builder \
+              //   /data/ci/images/gen_metal3_centos_image.sh \
+              //   /data/id_rsa_airshipci 1 \
+              //   provision_node_image_centos.sh"
+              }
             }
           }
         }


### PR DESCRIPTION
Currently, whenever a stage in node image and openstack image jobs is failed, the whole build stops. This PR helps to continue the build even when a stage is failed, and mark the build as `FAILURE` eventually.
