### PR TITLE
Add hosting container images in Harbor script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ integration_test: ## Run integration test
 build_ipa:
 	$(CURDIR)/ci/scripts/image_scripts/start_centos_ipa_ironic_build.sh
 
+.PHONY: sync_nordix_harbor
+sync_nordix_harbor:
+	$(CURDIR)/ci/scripts/image_scripts/synchronize_container_images.sh
+
 .PHONY: clean_ipa_builder_vm
 clean_ipa_builder_vm:
 	$(CURDIR)/ci/scripts/openstack/delete_openstack_vm.sh

--- a/ci/jobs/docker_image_building.pipeline
+++ b/ci/jobs/docker_image_building.pipeline
@@ -57,8 +57,9 @@ pipeline {
             }
             steps {
                 withCredentials([usernamePassword(credentialsId: 'airshipci_harbor', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASSWORD')])  {
-                sh "make sync_nordix_harbor"
+                    sh "docker login '${image_registry}' -u $DOCKER_USER -p $DOCKER_PASSWORD"
                 }
+                sh "make sync_nordix_harbor"
             }
         }
     }

--- a/ci/jobs/docker_image_building.pipeline
+++ b/ci/jobs/docker_image_building.pipeline
@@ -51,6 +51,16 @@ pipeline {
                 sh "make push-lint-go"
             }
         }
+        stage('Synchronize Nordix Harbor container images with quay.io'){
+            options {
+              timeout(time: 60, unit: 'MINUTES')
+            }
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'airshipci_harbor', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASSWORD')])  {
+                sh "make sync_nordix_harbor"
+                }
+            }
+        }
     }
     post {
       cleanup {

--- a/ci/scripts/image_scripts/synchronize_container_images.sh
+++ b/ci/scripts/image_scripts/synchronize_container_images.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -eu
+
+# This script makes sure to synchronize container images hosted in Nordix/Harbor
+# with the ones hosted in quay.io/metal3 based on the container image digest as tag.
+
+# Container image related variables
+UPSTREAM_IMAGE_REGISTRY="quay.io"
+UPSTREAM_CONTAINER_IMAGE_REPO="metal3-io"
+HARBOR_IMAGE_REGISTRY="registry.nordix.org"
+HARBOR_CONTAINER_IMAGE_REPO="airship"
+CAPM3_v1a4_RELEASE_TAG="release-0.4"
+IPAM_v1a4_RELEASE_TAG="release-0.0"
+CAPM3_IPAM_v1a5_RELEASE_TAG="master"
+
+# Container runtime
+export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+
+# Declare a string array with container image names
+declare -a ContainerImagesArray=(
+    "vbmc" "sushy-tools" "ironic-ipa-downloader" "ironic" \
+    "ironic-client" "keepalived" "baremetal-operator" \
+    "cluster-api-provider-metal3:${CAPM3_v1a4_RELEASE_TAG}" \
+    "cluster-api-provider-metal3:${CAPM3_IPAM_v1a5_RELEASE_TAG}" \
+    "ip-address-manager:${IPAM_v1a4_RELEASE_TAG}" \
+    "ip-address-manager:${CAPM3_IPAM_v1a5_RELEASE_TAG}"
+)
+
+# Loop over the container images and do:
+for container in "${ContainerImagesArray[@]}"; do
+    # Pull container image from quay.io
+    "${CONTAINER_RUNTIME}" pull "${UPSTREAM_IMAGE_REGISTRY}/${UPSTREAM_CONTAINER_IMAGE_REPO}/${container}"
+    # Get the sha256 digest of the container image
+    digest=$("${CONTAINER_RUNTIME}" inspect --format='{{index .RepoDigests 0}}' \
+        "${UPSTREAM_IMAGE_REGISTRY}/${UPSTREAM_CONTAINER_IMAGE_REPO}/${container}" \
+        | grep -o 'sha256:.*' | cut -f2- -d: | cut -c1-6)
+    echo "$container container image digest is $digest"
+    # Tag and push quay container image only if it doesn't already exist in the Nordix Harbor registry.
+    if "${CONTAINER_RUNTIME}" manifest inspect "${HARBOR_CONTAINER_IMAGE_REPO}/$container:${digest}"  > /dev/null; then
+        echo "${HARBOR_CONTAINER_IMAGE_REPO}/$container:${digest} container image already exists -> skip pushing container image to Nordix Harbor registry"
+    else
+        # Use digest of container image to tag and push it to Nordix Harbor registry
+        echo "${HARBOR_CONTAINER_IMAGE_REPO}/$container:${digest} container image doesn't exist -> tag and push container image to Nordix Harbor registry"
+        "${CONTAINER_RUNTIME}" tag "${UPSTREAM_IMAGE_REGISTRY}/${UPSTREAM_CONTAINER_IMAGE_REPO}/${container} \
+        ${HARBOR_IMAGE_REGISTRY}/${HARBOR_CONTAINER_IMAGE_REPO}/${container}:${digest}"
+        "${CONTAINER_RUNTIME}" push "${HARBOR_IMAGE_REGISTRY}/${HARBOR_CONTAINER_IMAGE_REPO}/${container}:${digest}"
+    fi
+done

--- a/ci/scripts/image_scripts/synchronize_container_images.sh
+++ b/ci/scripts/image_scripts/synchronize_container_images.sh
@@ -12,7 +12,7 @@ HARBOR_IMAGE_REGISTRY="registry.nordix.org"
 HARBOR_CONTAINER_IMAGE_REPO="airship"
 CAPM3_v1a4_RELEASE_TAG="release-0.4"
 IPAM_v1a4_RELEASE_TAG="release-0.0"
-CAPM3_IPAM_v1a5_RELEASE_TAG="master"
+v1a5_RELEASE_TAG="master"
 
 # Container runtime
 export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
@@ -22,9 +22,9 @@ declare -a ContainerImagesArray=(
     "vbmc" "sushy-tools" "ironic-ipa-downloader" "ironic" \
     "ironic-client" "keepalived" "baremetal-operator" \
     "cluster-api-provider-metal3:${CAPM3_v1a4_RELEASE_TAG}" \
-    "cluster-api-provider-metal3:${CAPM3_IPAM_v1a5_RELEASE_TAG}" \
+    "cluster-api-provider-metal3:${v1a5_RELEASE_TAG}" \
     "ip-address-manager:${IPAM_v1a4_RELEASE_TAG}" \
-    "ip-address-manager:${CAPM3_IPAM_v1a5_RELEASE_TAG}"
+    "ip-address-manager:${v1a5_RELEASE_TAG}"
 )
 
 # Loop over the container images and do:


### PR DESCRIPTION
This will be run as part of already existing docker_image_building pipeline we have that is run once every day because this pipeline already does push some container images (lint-md, lint-go) to the Nordix Harbor registry. 
The digest of the container image will be used as tag before pushing since that is unique, compared to having always the same tag in container images (i.e master or latest), using the latter we will not be able to differentiate container images whether they are synced with quay.io or not. 

Update:
The real motivation behind this patch is, certain images that we are using are hosted in quay.io, and sometimes we see service outage in the quay.io registry. For that reason, we want to host identical copies of all container images in Nordix Harbor registry to be used as a standby in case of quay.io inaccessibility.