### PR TITLE
Rename project-infra repo branch reference to main from master

### DIFF
--- a/ci/jobs/airship_integration_tests.pipeline
+++ b/ci/jobs/airship_integration_tests.pipeline
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat
 
-ci_git_branch = "master"
+ci_git_branch = "main"
 ci_git_url = "https://github.com/metal3-io/project-infra.git"
 ci_git_credential_id = "metal3-jenkins-github-token"
 


### PR DESCRIPTION
https://github.com/metal3-io/project-infra is using main as the default branch. So, 
updating reference here as well.