### PR TITLE
Pass k8s version variable for airship integration tests

### DIFF
--- a/ci/jobs/airship_integration_tests.pipeline
+++ b/ci/jobs/airship_integration_tests.pipeline
@@ -168,6 +168,7 @@ pipeline {
               sh """  cat <<-EOF > "./jenkins/scripts/files/vars.sh"
                 IMAGE_LOCATION="${IMAGE_LOCATION}"
                 IMAGE_NAME="${FINAL_IMAGE_NAME}.qcow2"
+                KUBERNETES_VERSION="${KUBERNETES_VERSION}"
 EOF
                 """
               sh "./jenkins/scripts/integration_test.sh"               


### PR DESCRIPTION
we need to pass KUBERNETES_VERSION variable when we want to check uplifting of k8s  version with airship integration tests. 
By adding it to vars.sh file we pass KUBERNETES_VERSION to metal3-dev-env