### PR TITLE
add ipa element that configures kernel modules

### DIFF
--- a/ci/scripts/image_scripts/ipa_builder_elements/ipa-module-autoload/install.d/80-ipa-module-autoload
+++ b/ci/scripts/image_scripts/ipa_builder_elements/ipa-module-autoload/install.d/80-ipa-module-autoload
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "${DIB_DEBUG_TRACE:-1}" -gt 0 ]; then
+    set -x
+fi
+set -eu
+set -o pipefail
+
+MODULES=${ADDITIONAL_IPA_KERNEL_MODULES:-""}
+
+for mod_name in $MODULES; do
+    echo "$mod_name" >> /etc/modules-load.d/load.conf
+done
+

--- a/ci/scripts/image_scripts/start_centos_ipa_ironic_build.sh
+++ b/ci/scripts/image_scripts/start_centos_ipa_ironic_build.sh
@@ -44,6 +44,14 @@ scp \
   "${CI_DIR}/run_build_ironic.sh" \
   "${AIRSHIP_CI_USER}@${BUILDER_IP}:/tmp/" > /dev/null
 
+# Send IPA builder custom element to remote executer
+scp \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -i "${AIRSHIP_CI_USER_KEY}" \
+  -r "${CI_DIR}/ipa_builder_elements" \
+  "${AIRSHIP_CI_USER}@${BUILDER_IP}:/tmp/" > /dev/null
+
 echo "Running Ironic image building script"
 # Execute remote script
 # shellcheck disable=SC2029


### PR DESCRIPTION
At the time of writing DIB has an element only for blacklisting
kernel drivers, and in order to support PERC11 sas controllers
the megaraid_sas kernel module is needed in IPA thus a custom
element was created to add support for configuring kernel module
loading during IPA boot.