### PR TITLE
WIP Add run dashboard

### DIFF
--- a/tools/dashboard/run_dashboard.sh
+++ b/tools/dashboard/run_dashboard.sh
@@ -1,5 +1,11 @@
-sudo apt -y install htop ruby
+sudo apt -y install htop ruby || sudo dnf -y install htop ruby
 sudo gem install tmuxinator
+
+ipam=$(kubectl get pods -A  |  awk '{print $1,$2}' | grep -m1 ipam-controller)
+capm3=$(kubectl get pods -A  |  awk '{print $1,$2}' | grep -m1 capm3-controller)
+bmo=$(kubectl get pods -A  |  awk '{print $1,$2}' | grep -m1 baremetal-operator-controller)
+capi=$(kubectl get pods -A  |  awk '{print $1,$2}' | grep -m1 capi-controller)
+
 sudo wget https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/completion/tmuxinator.bash -O /etc/bash_completion.d/tmuxinator.bash
 tmuxinator new dashboard
 cat <<-EOF > ~/.config/tmuxinator/dashboard.yml
@@ -14,5 +20,12 @@ windows:
         - watch kubectl get machine -A
         - htop
         - watch kubectl get pods -A -o wide
+  - logs:
+      layout: tiled
+      panes:
+        - kubectl logs  -n $capm3 -f 
+        - kubectl logs  -n $capi -f 
+        - kubectl logs  -n $bmo -f 
+        - kubectl logs  -n $ipam -f 
 EOF
 tmuxinator start dashboard


### PR DESCRIPTION
creating a dashboard giving an overview about the test running watch different crs, htop and logs and pods
TODO: customize layout, create a command that can detect when crs moved to target cluster so it use the kubeconfig and keep watching, find the needed pods name and show their logs, add parameter to get the Jenkins test logs and streaming them 