### PR TITLE
update repos synced

### DIFF
--- a/scripts/update-nordix-repos-master.sh
+++ b/scripts/update-nordix-repos-master.sh
@@ -56,12 +56,12 @@ declare -A REPOS=(
 declare -A OVERRIDE_BRANCHES=(
     [kubernetes-sigs/cluster-api]="main release-1.11 release-1.12 release-1.13"
     [kubernetes-sigs/cluster-api-provider-openstack]="main release-0.12 release-0.13 release-0.14"
-    [kubernetes/kubernetes]="master release-1.33 release-1.34 release-1.35"
-    [metal3-io/baremetal-operator]="main release-0.10 release-0.11 release-0.12"
-    [metal3-io/cluster-api-provider-metal3]="main release-1.10 release-1.11 release-1.12"
-    [metal3-io/ip-address-manager]="main release-1.10 release-1.11 release-1.12"
-    [metal3-io/ironic-image]="main release-29.0 release-31.0 release-32.0 release-33.0 release-34.0 release-35.0"
-    [metal3-io/ironic-standalone-operator]="main release-0.6 release-0.7 release-0.8"
+    [kubernetes/kubernetes]="master release-1.34 release-1.35 release-1.36"
+    [metal3-io/baremetal-operator]="main release-0.11 release-0.12 release-0.13"
+    [metal3-io/cluster-api-provider-metal3]="main release-1.11 release-1.12 release-1.13"
+    [metal3-io/ip-address-manager]="main release-1.11 release-1.12 release-1.13"
+    [metal3-io/ironic-image]="main release-31.0 release-32.0 release-33.0 release-34.0 release-35.0"
+    [metal3-io/ironic-standalone-operator]="main release-0.6 release-0.7 release-0.8 release-0.9"
 )
 
 FAILED=0


### PR DESCRIPTION
Add:
- release-1.36 for kubernetes
- release-0.13 for baremetal-operator
- release-1.13 for cluster-api-provider-metal3, ip-address-manager
- release-0.9 for ironic-standalone-operator

Drop
- release-0.10 for baremetal-operator
- release-1.10 for cluster-api-provider-metal3, ip-address-manager
- release-29.0 for ironic-image